### PR TITLE
fix: prevent focus zoom on mobile devices

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -107,6 +107,15 @@
   body > #root {
     @apply h-svh;
   }
+
+  /* Prevent focus zoom on mobile devices */
+  @media screen and (max-width: 767px) {
+    input,
+    select,
+    textarea {
+      font-size: 16px !important;
+    }
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
Set font-size to 16px for input, select, and
textarea elements on mobile screens to prevent
zooming when focused.