### PR TITLE
Update light/dark theme button to light/dark/system theme dropdown #29

### DIFF
--- a/src/components/theme-switch.tsx
+++ b/src/components/theme-switch.tsx
@@ -1,27 +1,65 @@
-import { IconMoon, IconSun } from '@tabler/icons-react'
-import { useTheme } from './theme-provider'
-import { Button } from './custom/button'
-import { useEffect } from 'react'
+import { IconMoon, IconSun, IconDeviceDesktop } from '@tabler/icons-react';
+import { useTheme } from './theme-provider';
+import { Button } from './custom/button'; 
+import { useEffect, useState } from 'react';
+
+// Define type for handleSelect parameter
+type Theme = 'light' | 'dark' | 'system';
 
 export default function ThemeSwitch() {
-  const { theme, setTheme } = useTheme()
+  const { theme, setTheme } = useTheme();
+  const [open, setOpen] = useState(false);
 
-  /* Update theme-color meta tag
-   * when theme is updated */
+  // Update theme-color meta tag when theme is updated
   useEffect(() => {
-    const themeColor = theme === 'dark' ? '#020817' : '#fff'
-    const metaThemeColor = document.querySelector("meta[name='theme-color']")
-    metaThemeColor && metaThemeColor.setAttribute('content', themeColor)
-  }, [theme])
+    const themeColor = theme === 'dark' ? '#020817' : '#fff';
+    const metaThemeColor = document.querySelector("meta[name='theme-color']");
+    metaThemeColor && metaThemeColor.setAttribute('content', themeColor);
+  }, [theme]);
+
+  // Explicitly type the parameter
+  const handleSelect = (value: Theme) => {
+    setTheme(value);
+    setOpen(false);
+  };
 
   return (
-    <Button
-      size='icon'
-      variant='ghost'
-      className='rounded-full'
-      onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-    >
-      {theme === 'light' ? <IconMoon size={20} /> : <IconSun size={20} />}
-    </Button>
-  )
+    <div className="relative">
+      <Button
+        size='icon'
+        variant='ghost'
+        className='rounded-full'
+        onClick={() => setOpen(!open)}
+      >
+        {theme === 'light' ? <IconSun size={20} /> : theme === 'dark' ? <IconMoon size={20} /> : <IconDeviceDesktop size={20} />}
+      </Button>
+      {open && (
+        <div
+          className="absolute top-full left-0 mt-2 w-35 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none z-50"
+        >
+          <div className="py-1">
+    
+            <button
+              onClick={() => handleSelect('light')}
+              className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+            >
+               Light
+            </button>
+            <button
+              onClick={() => handleSelect('dark')}
+              className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+            >
+               Dark
+            </button>
+            <button
+              onClick={() => handleSelect('system')}
+              className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+            >
+               System
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/components/theme-switch.tsx
+++ b/src/components/theme-switch.tsx
@@ -3,21 +3,20 @@ import { useTheme } from './theme-provider';
 import { Button } from './custom/button'; 
 import { useEffect, useState } from 'react';
 
-// Define type for handleSelect parameter
 type Theme = 'light' | 'dark' | 'system';
 
 export default function ThemeSwitch() {
   const { theme, setTheme } = useTheme();
   const [open, setOpen] = useState(false);
 
-  // Update theme-color meta tag when theme is updated
+ 
   useEffect(() => {
     const themeColor = theme === 'dark' ? '#020817' : '#fff';
     const metaThemeColor = document.querySelector("meta[name='theme-color']");
     metaThemeColor && metaThemeColor.setAttribute('content', themeColor);
   }, [theme]);
 
-  // Explicitly type the parameter
+  
   const handleSelect = (value: Theme) => {
     setTheme(value);
     setOpen(false);


### PR DESCRIPTION

This PR introduces a theme dropdown menu to replace the existing theme button. The dropdown allows users to select between Light, Dark, and System theme options. The following updates have been made:

1. **Theme Dropdown Menu**: Replaces the previous theme button with a dropdown menu.
2. **Icons**: 
   - Sun icon for Light theme
   - Moon icon for Dark theme
3. **Functionality**:
   - **Light Mode**: Switches to light mode and closes the dropdown upon selection.
   - **Dark Mode**: Switches to dark mode and closes the dropdown upon selection.
   - **System Mode**: Adapts to the system's theme settings.
4. **Dropdown Behavior**: The dropdown closes automatically after a selection is made.

### Changes Made

- Replaced the theme button with a dropdown menu in the UI.
- Implemented theme switching functionality:
  - **Light Mode**: Activated using the sun icon.
  - **Dark Mode**: Activated using the moon icon.
  - **System Mode**: Adapts based on the system's theme settings.

### Related Issues

- Issue #29  

### Screenshots

![image](https://github.com/user-attachments/assets/2065e063-49f3-4db4-b72a-acb9740a724d)
![image](https://github.com/user-attachments/assets/b8057ff4-068c-493d-824f-68f235999f1b)
![image](https://github.com/user-attachments/assets/1d33b6e9-6dcf-4501-952a-36e990704f26)


### Testing

- Verified that theme switching works correctly for Light, Dark, and System modes.
- Ensured the dropdown closes after making a selection.
- Tested across different browsers and devices for consistent behavior.

### Additional Notes

- Please review the changes to ensure they align with the project's theme and style guidelines.
- Feedback on the implementation and any additional improvements are welcome.

Thank you for reviewing this PR!

---

**Author**: Rachana Rane
**Date**: 27-08-24

