### PR TITLE
fix: loading all tabler-icon chunks in dev mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+
+      // fix loading all icon chunks in dev mode
+      // https://github.com/tabler/tabler-icons/issues/1233
+      '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs',
     },
   },
 })


### PR DESCRIPTION
Unnecessary tabler icon chunks are loaded in dev
mode which causes the performance issue during development. This issue is solved by replacing the import alias for '@tabler/icons-react' in vite.config.ts

Resolves #54