### PR TITLE
fix: add gap between buttons in import task dialog

### DIFF
--- a/src/features/tasks/components/tasks-import-dialog.tsx
+++ b/src/features/tasks/components/tasks-import-dialog.tsx
@@ -102,7 +102,7 @@ export function TasksImportDialog({ open, onOpenChange }: Props) {
             />
           </form>
         </Form>
-        <DialogFooter>
+        <DialogFooter className='gap-2 sm:gap-0'>
           <DialogClose asChild>
             <Button variant='outline'>Close</Button>
           </DialogClose>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1bd32ba0-4bb0-4710-95ae-0c444a631e48)
