### PR TITLE
feat: add multiple deletion for users and tasks tables

### DIFF
--- a/src/features/tasks/components/data-table-toolbar.tsx
+++ b/src/features/tasks/components/data-table-toolbar.tsx
@@ -1,8 +1,13 @@
 import { Cross2Icon } from '@radix-ui/react-icons'
 import { Table } from '@tanstack/react-table'
+import { Trash2Icon } from 'lucide-react'
+import useDialogState from '@/hooks/use-dialog-state'
+import { toast } from '@/hooks/use-toast'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { DataTableViewOptions } from '../components/data-table-view-options'
+import { TasksDialogType } from '../context/tasks-context'
 import { priorities, statuses } from '../data/data'
 import { DataTableFacetedFilter } from './data-table-faceted-filter'
 
@@ -14,7 +19,7 @@ export function DataTableToolbar<TData>({
   table,
 }: DataTableToolbarProps<TData>) {
   const isFiltered = table.getState().columnFilters.length > 0
-
+  const [open, setOpen] = useDialogState<TasksDialogType>(null)
   return (
     <div className='flex items-center justify-between'>
       <div className='flex flex-1 flex-col-reverse items-start gap-y-2 sm:flex-row sm:items-center sm:space-x-2'>
@@ -52,8 +57,50 @@ export function DataTableToolbar<TData>({
             <Cross2Icon className='ml-2 h-4 w-4' />
           </Button>
         )}
+        {table.getSelectedRowModel().rows.length > 1 && (
+          <Trash2Icon
+            className={'text-red-600 ml-2 cursor-pointer'}
+            size={18}
+            onClick={() => setOpen('multiple-delete')}
+          />
+        )}
       </div>
       <DataTableViewOptions table={table} />
+      <ConfirmDialog
+        key='tasks-delete'
+        destructive
+        open={open === 'multiple-delete'}
+        onOpenChange={() => {
+          setOpen('multiple-delete')
+        }}
+        handleConfirm={() => {
+          setOpen(null)
+          toast({
+            title: 'The following tasks have been deleted:',
+            description: (
+              <pre className='mt-2 w-[340px] rounded-md bg-slate-950 p-4'>
+                <code className='text-white'>
+                  {table.getSelectedRowModel().rows.map((row) => (
+                    <>
+                      {JSON.stringify(row.getValue('id'), null, 2)}
+                      <br />
+                    </>
+                  ))}
+                </code>
+              </pre>
+            ),
+          })
+        }}
+        className='max-w-md'
+        title={`Delete selected tasks ?`}
+        desc={
+          <>
+            You are about to delete the selected Tasks. <br />
+            This action cannot be undone.
+          </>
+        }
+        confirmText='Delete'
+      />
     </div>
   )
 }

--- a/src/features/tasks/context/tasks-context.tsx
+++ b/src/features/tasks/context/tasks-context.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { Task } from '../data/schema'
 
-export type TasksDialogType = 'create' | 'update' | 'delete' | 'import'
+export type TasksDialogType =
+  | 'create'
+  | 'update'
+  | 'delete'
+  | 'multiple-delete'
+  | 'import'
 
 interface TasksContextType {
   open: TasksDialogType | null

--- a/src/features/users/components/data-table-toolbar.tsx
+++ b/src/features/users/components/data-table-toolbar.tsx
@@ -1,10 +1,14 @@
 import { Cross2Icon } from '@radix-ui/react-icons'
 import { Table } from '@tanstack/react-table'
+import { Trash2Icon } from 'lucide-react'
+import useDialogState from '@/hooks/use-dialog-state'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { UsersDialogType } from '../context/users-context'
 import { userTypes } from '../data/data'
 import { DataTableFacetedFilter } from './data-table-faceted-filter'
 import { DataTableViewOptions } from './data-table-view-options'
+import { UsersDeleteMultipleDialog } from './users-delete-multiple-dialog'
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>
@@ -14,7 +18,7 @@ export function DataTableToolbar<TData>({
   table,
 }: DataTableToolbarProps<TData>) {
   const isFiltered = table.getState().columnFilters.length > 0
-
+  const [open, setOpen] = useDialogState<UsersDialogType>(null)
   return (
     <div className='flex items-center justify-between'>
       <div className='flex flex-1 flex-col-reverse items-start gap-y-2 sm:flex-row sm:items-center sm:space-x-2'>
@@ -59,8 +63,24 @@ export function DataTableToolbar<TData>({
             <Cross2Icon className='ml-2 h-4 w-4' />
           </Button>
         )}
+        {table.getSelectedRowModel().rows.length > 1 && (
+          <Trash2Icon
+            className={'text-red-600 ml-2 cursor-pointer'}
+            size={18}
+            onClick={() => setOpen('multiple-delete')}
+          />
+        )}
       </div>
+
       <DataTableViewOptions table={table} />
+      <UsersDeleteMultipleDialog
+        key={`users-delete-multiple`}
+        open={open === 'multiple-delete'}
+        onOpenChange={() => {
+          setOpen('multiple-delete')
+        }}
+        table={table}
+      />
     </div>
   )
 }

--- a/src/features/users/components/users-delete-multiple-dialog.tsx
+++ b/src/features/users/components/users-delete-multiple-dialog.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState } from 'react'
+import { Table } from '@tanstack/react-table'
+import { IconAlertTriangle } from '@tabler/icons-react'
+import { toast } from '@/hooks/use-toast'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+
+export interface Props<TData> {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  table: Table<TData>
+}
+
+export function UsersDeleteMultipleDialog<TData>({
+  open,
+  onOpenChange,
+  table,
+}: Props<TData>) {
+  const [value, setValue] = useState('')
+
+  const handleDeleteMultiple = () => {
+    onOpenChange(false)
+    setValue('')
+    toast({
+      title: 'The following users have been deleted:',
+      description: (
+        <pre className='mt-2 w-[340px] rounded-md bg-slate-950 p-4'>
+          <code className='text-white'>
+            {table.getSelectedRowModel().rows.map((row) => (
+              <>
+                {JSON.stringify(row.getValue('username'), null, 2)}
+                <br />
+              </>
+            ))}
+          </code>
+        </pre>
+      ),
+    })
+  }
+
+  return (
+    <ConfirmDialog
+      key='users-delete-multiple'
+      open={open}
+      disabled={!['Yes', 'yes', 'YES'].includes(value.trim())}
+      title={
+        <span className='text-destructive'>
+          <IconAlertTriangle
+            className='mr-1 inline-block stroke-destructive'
+            size={18}
+          />{' '}
+          Delete Users
+        </span>
+      }
+      onOpenChange={onOpenChange}
+      handleConfirm={handleDeleteMultiple}
+      desc={
+        <div className='space-y-4'>
+          <p className='mb-2'>Are you sure you want to delete ?</p>
+
+          <Label className='my-2'>
+            Confirmation:
+            <Input
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder='Enter yes to confirm deletion.'
+              className={'mt-2'}
+            />
+          </Label>
+
+          <Alert variant='destructive'>
+            <AlertTitle>Warning!</AlertTitle>
+            <AlertDescription>
+              Please be carefull, this operation can not be rolled back.
+            </AlertDescription>
+          </Alert>
+        </div>
+      }
+      confirmText='Delete'
+      destructive
+    />
+  )
+}

--- a/src/features/users/context/users-context.tsx
+++ b/src/features/users/context/users-context.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { User } from '../data/schema'
 
-export type UsersDialogType = 'invite' | 'add' | 'edit' | 'delete'
+export type UsersDialogType =
+  | 'invite'
+  | 'add'
+  | 'edit'
+  | 'delete'
+  | 'multiple-delete'
 
 interface UsersContextType {
   open: UsersDialogType | null


### PR DESCRIPTION
- add multiple delete function on tasks and users table
![delete multiple tasks toast](https://github.com/user-attachments/assets/79cb6d31-dbaa-4c3e-882c-b2ca92486e40)
![delete tasks dialog](https://github.com/user-attachments/assets/422be73a-1529-4488-a7f9-3b6dd073e013)
![delete users dialog](https://github.com/user-attachments/assets/4412ffaa-d0cf-4b75-8cdb-fee1cd12226e)
![delete users toast](https://github.com/user-attachments/assets/72dc6453-899e-4260-8b81-c4257d983fa6)
