### PR TITLE
fix: toolbar filter placeholder typo in user table

### DIFF
--- a/src/features/users/components/data-table-toolbar.tsx
+++ b/src/features/users/components/data-table-toolbar.tsx
@@ -19,7 +19,7 @@ export function DataTableToolbar<TData>({
     <div className='flex items-center justify-between'>
       <div className='flex flex-1 flex-col-reverse items-start gap-y-2 sm:flex-row sm:items-center sm:space-x-2'>
         <Input
-          placeholder='Filter tasks...'
+          placeholder='Filter users...'
           value={
             (table.getColumn('username')?.getFilterValue() as string) ?? ''
           }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

This pull request updates the placeholder text in the data-table-toolbar.tsx file for the user table. The placeholder has been changed from `Filter tasks...` to `Filter users...` to ensure clarity and better context for filtering user-related data.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This change is straightforward and focuses on improving the user interface for the user table.

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #<!-- Issue number, if applicable -->