### PR TITLE
fix: context provider usage in UsersContext component

### DIFF
--- a/src/features/users/context/users-context.tsx
+++ b/src/features/users/context/users-context.tsx
@@ -22,9 +22,9 @@ export default function UsersProvider({ children }: Props) {
   const [currentRow, setCurrentRow] = useState<User | null>(null)
 
   return (
-    <UsersContext value={{ open, setOpen, currentRow, setCurrentRow }}>
+    <UsersContext.Provider value={{ open, setOpen, currentRow, setCurrentRow }}>
       {children}
-    </UsersContext>
+    </UsersContext.Provider>
   )
 }
 


### PR DESCRIPTION
## Description
Corrects the usage of UsersContext.Provider in the UsersProvider component to ensure context values are provided to child components.
<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #<!-- Issue number, if applicable -->