### PR TITLE
fix: update sidebar color in dark mode for consistent look

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -63,14 +63,14 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-background: var(--background);
+    --sidebar-foreground: var(--foreground);
+    --sidebar-primary: var(--primary);
+    --sidebar-primary-foreground: var(--primary-foreground);
+    --sidebar-accent: var(--accent);
+    --sidebar-accent-foreground: var(--accent-foreground);
+    --sidebar-border: var(--border);
+    --sidebar-ring: var(--ring);
   }
 
   /* styles.css */


### PR DESCRIPTION
## Description

I apologize before, I think the sidebar color for dark mode doesn't have the same style as the overall (dark mode) design, color, and look & feel, for light mode I think it still fits, but for dark mode it's like a different design

## Types of changes

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Related Issue

Before :
![image](https://github.com/user-attachments/assets/54219d6c-e6d6-4f1a-b45a-dd0e59e10de2)


After : 
![image](https://github.com/user-attachments/assets/249859ef-5e52-4f11-a706-f380a14d2eeb)
