### PR TITLE
chore: prevent stale workflow from closing issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,13 +16,14 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-issue-stale: 15
-        days-before-issue-close: 15
+        days-before-issue-stale: 120
+        days-before-issue-close: 120
         stale-issue-label: "stale"
-        stale-issue-message: "This issue is stale because it has been open for 15 days with no activity."
-        close-issue-message: "This issue was closed because it has been inactive for 15 days since being marked as stale."
-        days-before-pr-stale: 23
-        days-before-pr-close: 7
+        stale-issue-message: "This issue is stale because it has been open for 120 days with no activity."
+        close-issue-message: "This issue was closed because it has been inactive for 120 days since being marked as stale."
+        days-before-pr-stale: 120
+        days-before-pr-close: 120
         stale-pr-label: "stale"
-        stale-pr-message: "This PR is stale because it has been open for 23 days with no activity."
-        close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
+        stale-pr-message: "This PR is stale because it has been open for 120 days with no activity."
+        close-pr-message: "This PR was closed because it has been inactive for 120 days since being marked as stale."
+        operations-per-run: 0


### PR DESCRIPTION
## Description

Prevent GitHub Actions from closing issues/PRs accidentally while I'm busy.
This is just temporary—I’ll take a closer look soon.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)