### PR TITLE
fix: broken focus behavior in add user dialog

### DIFF
--- a/src/features/users/components/users-action-dialog.tsx
+++ b/src/features/users/components/users-action-dialog.tsx
@@ -22,7 +22,6 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { PasswordInput } from '@/components/password-input'
 import { SelectDropdown } from '@/components/select-dropdown'
 import { userTypes } from '../data/data'
@@ -149,7 +148,7 @@ export function UsersActionDialog({ currentRow, open, onOpenChange }: Props) {
             Click save when you&apos;re done.
           </DialogDescription>
         </DialogHeader>
-        <ScrollArea className='-mr-4 h-[26.25rem] w-full py-1 pr-4'>
+        <div className='-mr-4 h-[26.25rem] w-full overflow-y-auto py-1 pr-4'>
           <Form {...form}>
             <form
               id='user-form'
@@ -316,7 +315,7 @@ export function UsersActionDialog({ currentRow, open, onOpenChange }: Props) {
               />
             </form>
           </Form>
-        </ScrollArea>
+        </div>
         <DialogFooter>
           <Button type='submit' form='user-form'>
             Save changes


### PR DESCRIPTION

## Description

Focus inside add user dialog is broken. Second input field should be focused after the first input. Instead modal dialog is focused. This is fixed by removing scroll-area with vertical scrollable div element.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Resolves #100