### PR TITLE
feat: add loading indicator during page transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-day-picker": "8.10.1",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.0",
+    "react-top-loading-bar": "^3.0.2",
     "recharts": "^2.14.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.0
         version: 7.54.0(react@19.0.0)
+      react-top-loading-bar:
+        specifier: ^3.0.2
+        version: 3.0.2(react@19.0.0)
       recharts:
         specifier: ^2.14.1
         version: 2.14.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2586,6 +2589,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-top-loading-bar@3.0.2:
+    resolution: {integrity: sha512-hW0CHrHqKdBOBsVhms73ka0rgb9/aoiRfqo7jiS1vwIYDK7VkyMj52ypo5ewhshTQGHKE6mRvR99GZBZ+FuM/Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16 || ^17 || ^18 || ^19
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -5157,6 +5166,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.1
+
+  react-top-loading-bar@3.0.2(react@19.0.0):
+    dependencies:
+      react: 19.0.0
 
   react-transition-group@4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:

--- a/src/components/navigation-progress.tsx
+++ b/src/components/navigation-progress.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react'
+import { useRouterState } from '@tanstack/react-router'
+import LoadingBar, { LoadingBarRef } from 'react-top-loading-bar'
+
+export function NavigationProgress() {
+  const ref = useRef<LoadingBarRef>(null)
+  const state = useRouterState()
+
+  useEffect(() => {
+    if (state.status === 'pending') {
+      ref.current?.continuousStart()
+    } else {
+      ref.current?.complete()
+    }
+  }, [state.status])
+
+  return <LoadingBar color='#2563eb' ref={ref} shadow={true} height={2} />
+}

--- a/src/components/navigation-progress.tsx
+++ b/src/components/navigation-progress.tsx
@@ -14,5 +14,12 @@ export function NavigationProgress() {
     }
   }, [state.status])
 
-  return <LoadingBar color='#2563eb' ref={ref} shadow={true} height={2} />
+  return (
+    <LoadingBar
+      color='hsl(var(--muted-foreground))'
+      ref={ref}
+      shadow={true}
+      height={2}
+    />
+  )
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { Toaster } from '@/components/ui/toaster'
+import { NavigationProgress } from '@/components/navigation-progress'
 import GeneralError from '@/features/errors/general-error'
 import NotFoundError from '@/features/errors/not-found-error'
 
@@ -12,6 +13,7 @@ export const Route = createRootRouteWithContext<{
   component: () => {
     return (
       <>
+        <NavigationProgress />
         <Outlet />
         <Toaster />
         {import.meta.env.MODE === 'development' && (


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

This PR implements a loading indicator that appears during route transitions, addressing #81.

![image](https://github.com/user-attachments/assets/0a89cae9-c354-43be-a7df-9f262016175b)


Changes Made:
- Integrated a loading top progress bar ([react-top-loading-bar](https://www.npmjs.com/package/react-top-loading-bar)) that shows when navigating between pages.
- Used `useRouterState` to detect loading states.

Why This Is Useful:
- Improves user experience by giving feedback during page transitions.
- Makes the admin interface feel more responsive and polished.

Let me know if there's anything else you'd like me to tweak or improve!

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #81 <!-- Issue number, if applicable -->