### PR TITLE
fix: add an indicator for nested pages in search

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import {
   IconArrowRightDashed,
+  IconChevronRight,
   IconDeviceLaptop,
   IconMoon,
   IconSun,
@@ -60,8 +61,8 @@ export function CommandMenu() {
 
                 return navItem.items?.map((subItem, i) => (
                   <CommandItem
-                    key={`${subItem.url}-${i}`}
-                    value={subItem.title}
+                    key={`${navItem.title}-${subItem.url}-${i}`}
+                    value={`${navItem.title}-${subItem.url}`}
                     onSelect={() => {
                       runCommand(() => navigate({ to: subItem.url }))
                     }}
@@ -69,7 +70,7 @@ export function CommandMenu() {
                     <div className='mr-2 flex h-4 w-4 items-center justify-center'>
                       <IconArrowRightDashed className='text-muted-foreground/80 size-2' />
                     </div>
-                    {subItem.title}
+                    {navItem.title} <IconChevronRight /> {subItem.title}
                   </CommandItem>
                 ))
               })}


### PR DESCRIPTION
## Description

Put an indicator for nested pages in search command menu.
This also helps duplicate value issue.

<img width="882" alt="Screenshot 2025-05-25 at 10 33 04 AM" src="https://github.com/user-attachments/assets/c4c98873-2c91-4083-81c5-07939a99c7cb" />

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)