### PR TITLE
fix(ui): correct dark mode hover background for font dropdown on sett…

### DIFF
--- a/src/features/settings/appearance/appearance-form.tsx
+++ b/src/features/settings/appearance/appearance-form.tsx
@@ -67,7 +67,8 @@ export function AppearanceForm() {
                   <select
                     className={cn(
                       buttonVariants({ variant: 'outline' }),
-                      'w-[200px] appearance-none font-normal capitalize'
+                      'w-[200px] appearance-none font-normal capitalize',
+                      'dark:bg-background dark:hover:bg-background'
                     )}
                     {...field}
                   >


### PR DESCRIPTION
## Description

Fixes an issue where the font dropdown on the settings/appearance page had a white background and white text in dark mode, making the options unreadable. This change adds appropriate dark mode classes to ensure the dropdown background and hover state remain consistent with the theme.

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Further comments

This is a small fix that applies `dark:bg-background` and `dark:hover:bg-background` to the `<select>` element to ensure proper contrast in dark mode. Let me know if you'd like any adjustments or if you'd prefer a different className approach.

## Related Issue

Closes: #145
