### PR TITLE
fix: overflow background in tables

### DIFF
--- a/src/features/tasks/components/data-table.tsx
+++ b/src/features/tasks/components/data-table.tsx
@@ -66,7 +66,7 @@ export function DataTable<TData, TValue>({
   return (
     <div className='space-y-4'>
       <DataTableToolbar table={table} />
-      <div className='rounded-md border'>
+      <div className='overflow-hidden rounded-md border'>
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/src/features/users/components/users-table.tsx
+++ b/src/features/users/components/users-table.tsx
@@ -69,7 +69,7 @@ export function UsersTable({ columns, data }: DataTableProps) {
   return (
     <div className='space-y-4'>
       <DataTableToolbar table={table} />
-      <div className='rounded-md border'>
+      <div className='overflow-hidden rounded-md border'>
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (


### PR DESCRIPTION
## Description

Hide overflow background colors when the table is hovered, or one/more rows are selected.

| Before | After |
| --- | --- |
| <img width="2160" height="1350" alt="image" src="https://github.com/user-attachments/assets/91e94ab5-6d0d-4159-838a-ba3f54ee47d9" /> | <img width="2160" height="1350" alt="image" src="https://github.com/user-attachments/assets/211bffc6-2f33-4d4b-b21f-4806a2d6bf90" /> |


## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)