### PR TITLE
fix: add max-width for large screens to improve responsiveness

### DIFF
--- a/src/components/layout/authenticated-layout.tsx
+++ b/src/components/layout/authenticated-layout.tsx
@@ -52,7 +52,10 @@ export function AuthenticatedLayout({ children }: Props) {
               // If layout is fixed and sidebar is inset,
               // set the height to 100svh - 1rem (total margins) to prevent overflow
               // 'peer-data-[variant=inset]:has-[[data-layout=fixed]]:h-[calc(100svh-1rem)]',
-              'peer-data-[variant=inset]:has-[[data-layout=fixed]]:h-[calc(100svh-(var(--spacing)*4))]'
+              'peer-data-[variant=inset]:has-[[data-layout=fixed]]:h-[calc(100svh-(var(--spacing)*4))]',
+
+              // Set content container, so we can use container queries
+              '@container/content'
             )}
           >
             {children ?? <Outlet />}

--- a/src/components/layout/main.tsx
+++ b/src/components/layout/main.tsx
@@ -3,16 +3,23 @@ import { cn } from '@/lib/utils'
 
 interface MainProps extends React.HTMLAttributes<HTMLElement> {
   fixed?: boolean
+  fluid?: boolean
   ref?: React.Ref<HTMLElement>
 }
 
-export const Main = ({ fixed, className, ...props }: MainProps) => {
+export const Main = ({ fixed, className, fluid, ...props }: MainProps) => {
   return (
     <main
       data-layout={fixed ? 'fixed' : 'auto'}
       className={cn(
         'px-4 py-6',
+
+        // If layout is fixed, make the main container flex and grow
         fixed && 'flex grow flex-col overflow-hidden',
+
+        // If layout is not fluid, set the max-width
+        !fluid &&
+          '@7xl/content:mx-auto @7xl/content:w-full @7xl/content:max-w-7xl',
         className
       )}
       {...props}


### PR DESCRIPTION
## Description

Added max-width for large screens

<img width="2638" height="1428" alt="image" src="https://github.com/user-attachments/assets/080d12dd-2a9a-40a9-8a5d-e55c98ebf8d5" />

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)
