### PR TITLE
feat: add data table bulk action toolbar

### DIFF
--- a/src/components/bulk-actions-toolbar.tsx
+++ b/src/components/bulk-actions-toolbar.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect, useRef } from 'react'
+import { Table } from '@tanstack/react-table'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+interface BulkActionsToolbarProps<TData> {
+  table: Table<TData>
+  entityName: string
+  children: React.ReactNode
+}
+
+/**
+ * A modular toolbar for displaying bulk actions when table rows are selected.
+ *
+ * @template TData The type of data in the table.
+ * @param {object} props The component props.
+ * @param {Table<TData>} props.table The react-table instance.
+ * @param {string} props.entityName The name of the entity being acted upon (e.g., "task", "user").
+ * @param {React.ReactNode} props.children The action buttons to be rendered inside the toolbar.
+ * @returns {React.ReactNode | null} The rendered component or null if no rows are selected.
+ */
+export function BulkActionsToolbar<TData>({
+  table,
+  entityName,
+  children,
+}: BulkActionsToolbarProps<TData>): React.ReactNode | null {
+  const selectedRows = table.getFilteredSelectedRowModel().rows
+  const selectedCount = selectedRows.length
+  const toolbarRef = useRef<HTMLDivElement>(null)
+  const [announcement, setAnnouncement] = useState('')
+
+  // Announce selection changes to screen readers
+  useEffect(() => {
+    if (selectedCount > 0) {
+      const message = `${selectedCount} ${entityName}${selectedCount > 1 ? 's' : ''} selected. Bulk actions toolbar is available.`
+      setAnnouncement(message)
+
+      // Clear announcement after a delay
+      const timer = setTimeout(() => setAnnouncement(''), 3000)
+      return () => clearTimeout(timer)
+    }
+  }, [selectedCount, entityName])
+
+  const handleClearSelection = () => {
+    table.resetRowSelection()
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    const buttons = toolbarRef.current?.querySelectorAll('button')
+    if (!buttons) return
+
+    const currentIndex = Array.from(buttons).findIndex(
+      (button) => button === document.activeElement
+    )
+
+    switch (event.key) {
+      case 'ArrowRight': {
+        event.preventDefault()
+        const nextIndex = (currentIndex + 1) % buttons.length
+        buttons[nextIndex]?.focus()
+        break
+      }
+      case 'ArrowLeft': {
+        event.preventDefault()
+        const prevIndex =
+          currentIndex === 0 ? buttons.length - 1 : currentIndex - 1
+        buttons[prevIndex]?.focus()
+        break
+      }
+      case 'Home':
+        event.preventDefault()
+        buttons[0]?.focus()
+        break
+      case 'End':
+        event.preventDefault()
+        buttons[buttons.length - 1]?.focus()
+        break
+      case 'Escape': {
+        // Check if the Escape key came from a dropdown trigger or content
+        // We can't check dropdown state because Radix UI closes it before our handler runs
+        const target = event.target as HTMLElement
+        const activeElement = document.activeElement as HTMLElement
+
+        // Check if the event target or currently focused element is a dropdown trigger
+        const isFromDropdownTrigger =
+          target?.getAttribute('data-slot') === 'dropdown-menu-trigger' ||
+          activeElement?.getAttribute('data-slot') ===
+            'dropdown-menu-trigger' ||
+          target?.closest('[data-slot="dropdown-menu-trigger"]') ||
+          activeElement?.closest('[data-slot="dropdown-menu-trigger"]')
+
+        // Check if the focused element is inside dropdown content (which is portaled)
+        const isFromDropdownContent =
+          activeElement?.closest('[data-slot="dropdown-menu-content"]') ||
+          target?.closest('[data-slot="dropdown-menu-content"]')
+
+        if (isFromDropdownTrigger || isFromDropdownContent) {
+          // Escape was meant for the dropdown - don't clear selection
+          return
+        }
+
+        // Escape was meant for the toolbar - clear selection
+        event.preventDefault()
+        handleClearSelection()
+        break
+      }
+    }
+  }
+
+  if (selectedCount === 0) {
+    return null
+  }
+
+  return (
+    <>
+      {/* Live region for screen reader announcements */}
+      <div
+        aria-live='polite'
+        aria-atomic='true'
+        className='sr-only'
+        role='status'
+      >
+        {announcement}
+      </div>
+
+      <div
+        ref={toolbarRef}
+        role='toolbar'
+        aria-label={`Bulk actions for ${selectedCount} selected ${entityName}${selectedCount > 1 ? 's' : ''}`}
+        aria-describedby='bulk-actions-description'
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          'fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-xl',
+          'transition-all delay-100 duration-300 ease-out hover:scale-105',
+          'focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:outline-none'
+        )}
+      >
+        <div
+          className={cn(
+            'p-2 shadow-xl',
+            'rounded-xl border',
+            'bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg',
+            'flex items-center gap-x-2'
+          )}
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                onClick={handleClearSelection}
+                className='size-6 rounded-full'
+                aria-label='Clear selection'
+                title='Clear selection (Escape)'
+              >
+                <X />
+                <span className='sr-only'>Clear selection</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Clear selection (Escape)</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Separator
+            className='h-5'
+            orientation='vertical'
+            aria-hidden='true'
+          />
+
+          <div
+            className='flex items-center gap-x-1 text-sm'
+            id='bulk-actions-description'
+          >
+            <Badge
+              variant='default'
+              className='min-w-8 rounded-lg'
+              aria-label={`${selectedCount} selected`}
+            >
+              {selectedCount}
+            </Badge>{' '}
+            <span className='hidden sm:inline'>
+              {entityName}
+              {selectedCount > 1 ? 's' : ''}
+            </span>{' '}
+            selected
+          </div>
+
+          <Separator
+            className='h-5'
+            orientation='vertical'
+            aria-hidden='true'
+          />
+
+          {children}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/features/tasks/components/data-table-bulk-actions.tsx
+++ b/src/features/tasks/components/data-table-bulk-actions.tsx
@@ -1,9 +1,7 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { Table } from '@tanstack/react-table'
-import { Trash2, X, CircleArrowUp, ArrowUpDown, Download } from 'lucide-react'
+import { Trash2, CircleArrowUp, ArrowUpDown, Download } from 'lucide-react'
 import { toast } from 'sonner'
-import { cn } from '@/lib/utils'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -11,12 +9,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Separator } from '@/components/ui/separator'
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { BulkActionsToolbar } from '@/components/bulk-actions-toolbar'
 import { priorities, statuses } from '../data/data'
 import { Task } from '../data/schema'
 import { TasksMultiDeleteDialog } from './tasks-multi-delete-dialog'
@@ -28,48 +26,14 @@ interface DataTableBulkActionsProps<TData> {
 const promise = () =>
   new Promise((resolve) => setTimeout(() => resolve(true), 2000))
 
-/**
- * Bulk Actions Component for Tasks Table
- *
- * This component provides bulk action functionality when tasks are selected in the table.
- * It includes:
- * - Bulk invite tasks
- * - Bulk activate tasks
- * - Bulk deactivate tasks
- * - Bulk delete tasks (with confirmation dialog)
- * - Clear selection option
- *
- * The component only renders when at least one row is selected.
- */
 export function DataTableBulkActions<TData>({
   table,
 }: DataTableBulkActionsProps<TData>) {
-  const selectedRows = table.getFilteredSelectedRowModel().rows
-  const selectedCount = selectedRows.length
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-  const toolbarRef = useRef<HTMLDivElement>(null)
-  const [announcement, setAnnouncement] = useState('')
-
-  // Announce selection changes to screen readers
-  useEffect(() => {
-    if (selectedCount > 0) {
-      const message = `${selectedCount} task${selectedCount > 1 ? 's' : ''} selected. Bulk actions toolbar is available.`
-      setAnnouncement(message)
-
-      // Clear announcement after a delay
-      const timer = setTimeout(() => setAnnouncement(''), 3000)
-      return () => clearTimeout(timer)
-    }
-  }, [selectedCount])
-
-  if (selectedCount === 0) {
-    return null
-  }
+  const selectedRows = table.getFilteredSelectedRowModel().rows
 
   const handleBulkStatusChange = (status: string) => {
-    // TODO: Implement bulk status change functionality
     const selectedTasks = selectedRows.map((row) => row.original as Task)
-
     toast.promise(promise, {
       loading: 'Updating status...',
       success: () => {
@@ -78,14 +42,11 @@ export function DataTableBulkActions<TData>({
       },
       error: 'Error',
     })
-    // For now, just clear selection
     table.resetRowSelection()
   }
 
   const handleBulkPriorityChange = (priority: string) => {
-    // TODO: Implement bulk priority change functionality
     const selectedTasks = selectedRows.map((row) => row.original as Task)
-
     toast.promise(promise, {
       loading: 'Updating priority...',
       success: () => {
@@ -94,14 +55,11 @@ export function DataTableBulkActions<TData>({
       },
       error: 'Error',
     })
-    // For now, just clear selection
     table.resetRowSelection()
   }
 
   const handleBulkExport = () => {
-    // TODO: Implement bulk export functionality
     const selectedTasks = selectedRows.map((row) => row.original as Task)
-
     toast.promise(promise, {
       loading: 'Exporting tasks...',
       success: () => {
@@ -110,272 +68,122 @@ export function DataTableBulkActions<TData>({
       },
       error: 'Error',
     })
-    // For now, just clear selection
     table.resetRowSelection()
-  }
-
-  const handleClearSelection = () => {
-    table.resetRowSelection()
-  }
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    // Handle keyboard navigation within the toolbar
-    const buttons = toolbarRef.current?.querySelectorAll('button')
-    if (!buttons) return
-
-    const currentIndex = Array.from(buttons).findIndex(
-      (button) => button === document.activeElement
-    )
-
-    switch (event.key) {
-      case 'ArrowRight': {
-        event.preventDefault()
-        const nextIndex = (currentIndex + 1) % buttons.length
-        buttons[nextIndex]?.focus()
-        break
-      }
-      case 'ArrowLeft': {
-        event.preventDefault()
-        const prevIndex =
-          currentIndex === 0 ? buttons.length - 1 : currentIndex - 1
-        buttons[prevIndex]?.focus()
-        break
-      }
-      case 'Home':
-        event.preventDefault()
-        buttons[0]?.focus()
-        break
-      case 'End':
-        event.preventDefault()
-        buttons[buttons.length - 1]?.focus()
-        break
-      case 'Escape': {
-        // Check if the Escape key came from a dropdown trigger or content
-        // We can't check dropdown state because Radix UI closes it before our handler runs
-        const target = event.target as HTMLElement
-        const activeElement = document.activeElement as HTMLElement
-
-        // Check if the event target or currently focused element is a dropdown trigger
-        const isFromDropdownTrigger =
-          target?.getAttribute('data-slot') === 'dropdown-menu-trigger' ||
-          activeElement?.getAttribute('data-slot') ===
-            'dropdown-menu-trigger' ||
-          target?.closest('[data-slot="dropdown-menu-trigger"]') ||
-          activeElement?.closest('[data-slot="dropdown-menu-trigger"]')
-
-        // Check if the focused element is inside dropdown content (which is portaled)
-        const isFromDropdownContent =
-          activeElement?.closest('[data-slot="dropdown-menu-content"]') ||
-          target?.closest('[data-slot="dropdown-menu-content"]')
-
-        if (isFromDropdownTrigger || isFromDropdownContent) {
-          // Escape was meant for the dropdown - don't clear selection
-          return
-        }
-
-        // Escape was meant for the toolbar - clear selection
-        event.preventDefault()
-        handleClearSelection()
-        break
-      }
-    }
   }
 
   return (
     <>
-      {/* Live region for screen reader announcements */}
-      <div
-        aria-live='polite'
-        aria-atomic='true'
-        className='sr-only'
-        role='status'
-      >
-        {announcement}
-      </div>
-
-      <div
-        ref={toolbarRef}
-        role='toolbar'
-        aria-label={`Bulk actions for ${selectedCount} selected task${selectedCount > 1 ? 's' : ''}`}
-        aria-describedby='bulk-actions-description'
-        tabIndex={0}
-        onKeyDown={handleKeyDown}
-        className={cn(
-          'fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-xl',
-          'transition-all delay-100 duration-300 ease-out hover:scale-105',
-          'focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:outline-none'
-        )}
-      >
-        <div
-          className={cn(
-            'p-2 shadow-xl',
-            'rounded-xl border',
-            'bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg',
-            'flex items-center gap-x-2'
-          )}
-        >
+      <BulkActionsToolbar table={table} entityName='task'>
+        <DropdownMenu>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant='outline'
-                size='icon'
-                onClick={handleClearSelection}
-                className='size-6 rounded-full'
-                aria-label='Clear selection'
-                title='Clear selection (Escape)'
-              >
-                <X />
-                <span className='sr-only'>Clear selection</span>
-              </Button>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant='outline'
+                  size='icon'
+                  className='size-8'
+                  aria-label='Update status'
+                  title='Update status'
+                >
+                  <CircleArrowUp />
+                  <span className='sr-only'>Update status</span>
+                </Button>
+              </DropdownMenuTrigger>
             </TooltipTrigger>
             <TooltipContent>
-              <p>Clear selection (Escape)</p>
+              <p>Update status</p>
             </TooltipContent>
           </Tooltip>
+          <DropdownMenuContent sideOffset={14}>
+            {statuses.map((status) => (
+              <DropdownMenuItem
+                key={status.value}
+                defaultValue={status.value}
+                onClick={() => handleBulkStatusChange(status.value)}
+              >
+                {status.icon && (
+                  <status.icon className='text-muted-foreground me-2 h-4 w-4' />
+                )}
+                {status.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
 
-          <Separator
-            className='h-5'
-            orientation='vertical'
-            aria-hidden='true'
-          />
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant='outline'
+                  size='icon'
+                  className='size-8'
+                  aria-label='Update priority'
+                  title='Update priority'
+                >
+                  <ArrowUpDown />
+                  <span className='sr-only'>Update priority</span>
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Update priority</p>
+            </TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent sideOffset={14}>
+            {priorities.map((priority) => (
+              <DropdownMenuItem
+                key={priority.value}
+                defaultValue={priority.value}
+                onClick={() => handleBulkPriorityChange(priority.value)}
+              >
+                {priority.icon && (
+                  <priority.icon className='text-muted-foreground me-2 h-4 w-4' />
+                )}
+                {priority.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
 
-          <div
-            className='flex items-center gap-x-1 text-sm'
-            id='bulk-actions-description'
-          >
-            <Badge
-              variant='default'
-              className='min-w-8 rounded-lg'
-              aria-label={`${selectedCount} selected`}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              onClick={() => handleBulkExport()}
+              className='size-8'
+              aria-label='Export tasks'
+              title='Export tasks'
             >
-              {selectedCount}
-            </Badge>
-            {'  '}
-            <span className='hidden sm:inline'>
-              task
-              {selectedCount > 1 ? 's' : ''}{' '}
-            </span>
-            {'  '}
-            selected
-          </div>
+              <Download />
+              <span className='sr-only'>Export tasks</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Export tasks</p>
+          </TooltipContent>
+        </Tooltip>
 
-          <Separator
-            className='h-5'
-            orientation='vertical'
-            aria-hidden='true'
-          />
-
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant='outline'
-                    size='icon'
-                    className='size-8'
-                    aria-label='Update status'
-                    title='Update status'
-                  >
-                    <CircleArrowUp />
-                    <span className='sr-only'>Update status</span>
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Update status</p>
-              </TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent sideOffset={14}>
-              {statuses.map((status) => (
-                <DropdownMenuItem
-                  key={status.value}
-                  defaultValue={status.value}
-                  onClick={() => handleBulkStatusChange(status.value)}
-                >
-                  {status.icon && (
-                    <status.icon className='text-muted-foreground me-2 h-4 w-4' />
-                  )}
-                  {status.label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant='outline'
-                    size='icon'
-                    className='size-8'
-                    aria-label='Update priority'
-                    title='Update priority'
-                  >
-                    <ArrowUpDown />
-                    <span className='sr-only'>Update priority</span>
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Update priority</p>
-              </TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent sideOffset={14}>
-              {priorities.map((priority) => (
-                <DropdownMenuItem
-                  key={priority.value}
-                  defaultValue={priority.value}
-                  onClick={() => handleBulkPriorityChange(priority.value)}
-                >
-                  {priority.icon && (
-                    <priority.icon className='text-muted-foreground me-2 h-4 w-4' />
-                  )}
-                  {priority.label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant='outline'
-                size='icon'
-                onClick={() => handleBulkExport()}
-                className='size-8'
-                aria-label='Export tasks'
-                title='Export tasks'
-              >
-                <Download />
-                <span className='sr-only'>Export tasks</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Export tasks</p>
-            </TooltipContent>
-          </Tooltip>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant='outline'
-                size='icon'
-                onClick={() => setShowDeleteConfirm(true)}
-                className='text-destructive/75 border-destructive/35 dark:text-destructive dark:border-destructive/50 hover:bg-destructive/5 hover:text-destructive size-8'
-                aria-label='Delete selected tasks'
-                title='Delete selected tasks'
-              >
-                <Trash2 />
-                <span className='sr-only'>Delete selected tasks</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Delete selected tasks</p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='destructive'
+              size='icon'
+              onClick={() => setShowDeleteConfirm(true)}
+              className='size-8'
+              aria-label='Delete selected tasks'
+              title='Delete selected tasks'
+            >
+              <Trash2 />
+              <span className='sr-only'>Delete selected tasks</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Delete selected tasks</p>
+          </TooltipContent>
+        </Tooltip>
+      </BulkActionsToolbar>
 
       <TasksMultiDeleteDialog
         open={showDeleteConfirm}

--- a/src/features/tasks/components/data-table-bulk-actions.tsx
+++ b/src/features/tasks/components/data-table-bulk-actions.tsx
@@ -1,0 +1,373 @@
+import { useState, useEffect, useRef } from 'react'
+import { Table } from '@tanstack/react-table'
+import { Trash2, X, CircleArrowUp, ArrowUpDown, Download } from 'lucide-react'
+import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Separator } from '@/components/ui/separator'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { priorities, statuses } from '../data/data'
+import { Task } from '../data/schema'
+import { TasksMultiDeleteDialog } from './tasks-multi-delete-dialog'
+
+interface DataTableBulkActionsProps<TData> {
+  table: Table<TData>
+}
+
+const promise = () =>
+  new Promise((resolve) => setTimeout(() => resolve(true), 2000))
+
+/**
+ * Bulk Actions Component for Tasks Table
+ *
+ * This component provides bulk action functionality when tasks are selected in the table.
+ * It includes:
+ * - Bulk invite tasks
+ * - Bulk activate tasks
+ * - Bulk deactivate tasks
+ * - Bulk delete tasks (with confirmation dialog)
+ * - Clear selection option
+ *
+ * The component only renders when at least one row is selected.
+ */
+export function DataTableBulkActions<TData>({
+  table,
+}: DataTableBulkActionsProps<TData>) {
+  const selectedRows = table.getFilteredSelectedRowModel().rows
+  const selectedCount = selectedRows.length
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const toolbarRef = useRef<HTMLDivElement>(null)
+  const [announcement, setAnnouncement] = useState('')
+
+  // Announce selection changes to screen readers
+  useEffect(() => {
+    if (selectedCount > 0) {
+      const message = `${selectedCount} task${selectedCount > 1 ? 's' : ''} selected. Bulk actions toolbar is available.`
+      setAnnouncement(message)
+
+      // Clear announcement after a delay
+      const timer = setTimeout(() => setAnnouncement(''), 3000)
+      return () => clearTimeout(timer)
+    }
+  }, [selectedCount])
+
+  // Focus management - focus the toolbar when it appears
+  useEffect(() => {
+    if (selectedCount > 0 && toolbarRef.current) {
+      // Small delay to ensure the toolbar is rendered
+      const timer = setTimeout(() => {
+        toolbarRef.current?.focus()
+      }, 100)
+      return () => clearTimeout(timer)
+    }
+  }, [selectedCount])
+
+  if (selectedCount === 0) {
+    return null
+  }
+
+  const handleBulkStatusChange = (status: string) => {
+    // TODO: Implement bulk status change functionality
+    const selectedTasks = selectedRows.map((row) => row.original as Task)
+
+    toast.promise(promise, {
+      loading: 'Updating status...',
+      success: () => {
+        table.resetRowSelection()
+        return `Status updated to "${status}" for ${selectedTasks.length} task${selectedTasks.length > 1 ? 's' : ''}.`
+      },
+      error: 'Error',
+    })
+    // For now, just clear selection
+    table.resetRowSelection()
+  }
+
+  const handleBulkPriorityChange = (priority: string) => {
+    // TODO: Implement bulk priority change functionality
+    const selectedTasks = selectedRows.map((row) => row.original as Task)
+
+    toast.promise(promise, {
+      loading: 'Updating priority...',
+      success: () => {
+        table.resetRowSelection()
+        return `Priority updated to "${priority}" for ${selectedTasks.length} task${selectedTasks.length > 1 ? 's' : ''}.`
+      },
+      error: 'Error',
+    })
+    // For now, just clear selection
+    table.resetRowSelection()
+  }
+
+  const handleBulkExport = () => {
+    // TODO: Implement bulk export functionality
+    const selectedTasks = selectedRows.map((row) => row.original as Task)
+
+    toast.promise(promise, {
+      loading: 'Exporting tasks...',
+      success: () => {
+        table.resetRowSelection()
+        return `Exported ${selectedTasks.length} task${selectedTasks.length > 1 ? 's' : ''} to CSV.`
+      },
+      error: 'Error',
+    })
+    // For now, just clear selection
+    table.resetRowSelection()
+  }
+
+  const handleClearSelection = () => {
+    table.resetRowSelection()
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    // Handle keyboard navigation within the toolbar
+    const buttons = toolbarRef.current?.querySelectorAll('button')
+    if (!buttons) return
+
+    const currentIndex = Array.from(buttons).findIndex(
+      (button) => button === document.activeElement
+    )
+
+    switch (event.key) {
+      case 'ArrowRight': {
+        event.preventDefault()
+        const nextIndex = (currentIndex + 1) % buttons.length
+        buttons[nextIndex]?.focus()
+        break
+      }
+      case 'ArrowLeft': {
+        event.preventDefault()
+        const prevIndex =
+          currentIndex === 0 ? buttons.length - 1 : currentIndex - 1
+        buttons[prevIndex]?.focus()
+        break
+      }
+      case 'Home':
+        event.preventDefault()
+        buttons[0]?.focus()
+        break
+      case 'End':
+        event.preventDefault()
+        buttons[buttons.length - 1]?.focus()
+        break
+      case 'Escape':
+        event.preventDefault()
+        handleClearSelection()
+        break
+    }
+  }
+
+  return (
+    <>
+      {/* Live region for screen reader announcements */}
+      <div
+        aria-live='polite'
+        aria-atomic='true'
+        className='sr-only'
+        role='status'
+      >
+        {announcement}
+      </div>
+
+      <div
+        ref={toolbarRef}
+        role='toolbar'
+        aria-label={`Bulk actions for ${selectedCount} selected task${selectedCount > 1 ? 's' : ''}`}
+        aria-describedby='bulk-actions-description'
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          'fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-xl',
+          'transition-all delay-100 duration-300 ease-out hover:scale-105',
+          'focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:outline-none'
+        )}
+      >
+        <div
+          className={cn(
+            'p-2 shadow-xl',
+            'rounded-xl border',
+            'bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg',
+            'flex items-center gap-x-2'
+          )}
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                onClick={handleClearSelection}
+                className='size-6 rounded-full'
+                aria-label='Clear selection'
+                title='Clear selection (Escape)'
+              >
+                <X />
+                <span className='sr-only'>Clear selection</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Clear selection (Escape)</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Separator
+            className='h-5'
+            orientation='vertical'
+            aria-hidden='true'
+          />
+
+          <div
+            className='flex items-center gap-x-1 text-sm'
+            id='bulk-actions-description'
+          >
+            <Badge
+              variant='default'
+              className='min-w-8 rounded-lg'
+              aria-label={`${selectedCount} selected`}
+            >
+              {selectedCount}
+            </Badge>
+            {'  '}
+            <span className='hidden sm:inline'>
+              task
+              {selectedCount > 1 ? 's' : ''}{' '}
+            </span>
+            {'  '}
+            selected
+          </div>
+
+          <Separator
+            className='h-5'
+            orientation='vertical'
+            aria-hidden='true'
+          />
+
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='outline'
+                    size='icon'
+                    className='size-8'
+                    aria-label='Update status'
+                    title='Update status'
+                  >
+                    <CircleArrowUp />
+                    <span className='sr-only'>Update status</span>
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Update status</p>
+              </TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent sideOffset={14}>
+              {statuses.map((status) => (
+                <DropdownMenuItem
+                  key={status.value}
+                  defaultValue={status.value}
+                  onClick={() => handleBulkStatusChange(status.value)}
+                >
+                  {status.icon && (
+                    <status.icon className='text-muted-foreground me-2 h-4 w-4' />
+                  )}
+                  {status.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='outline'
+                    size='icon'
+                    className='size-8'
+                    aria-label='Update priority'
+                    title='Update priority'
+                  >
+                    <ArrowUpDown />
+                    <span className='sr-only'>Update priority</span>
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Update priority</p>
+              </TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent sideOffset={14}>
+              {priorities.map((priority) => (
+                <DropdownMenuItem
+                  key={priority.value}
+                  defaultValue={priority.value}
+                  onClick={() => handleBulkPriorityChange(priority.value)}
+                >
+                  {priority.icon && (
+                    <priority.icon className='text-muted-foreground me-2 h-4 w-4' />
+                  )}
+                  {priority.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                onClick={() => handleBulkExport()}
+                className='size-8'
+                aria-label='Export tasks'
+                title='Export tasks'
+              >
+                <Download />
+                <span className='sr-only'>Export tasks</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Export tasks</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                onClick={() => setShowDeleteConfirm(true)}
+                className='text-destructive/75 border-destructive/35 dark:text-destructive dark:border-destructive/50 hover:bg-destructive/5 hover:text-destructive size-8'
+                aria-label='Delete selected tasks'
+                title='Delete selected tasks'
+              >
+                <Trash2 />
+                <span className='sr-only'>Delete selected tasks</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Delete selected tasks</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      <TasksMultiDeleteDialog
+        open={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+        table={table}
+      />
+    </>
+  )
+}

--- a/src/features/tasks/components/data-table.tsx
+++ b/src/features/tasks/components/data-table.tsx
@@ -65,7 +65,7 @@ export function DataTable<TData, TValue>({
   })
 
   return (
-    <div className='space-y-4'>
+    <div className='space-y-4 max-sm:has-[div[role="toolbar"]]:mb-16'>
       <DataTableToolbar table={table} />
       <div className='overflow-hidden rounded-md border'>
         <Table>

--- a/src/features/tasks/components/data-table.tsx
+++ b/src/features/tasks/components/data-table.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/table'
 import { DataTablePagination } from '../components/data-table-pagination'
 import { DataTableToolbar } from '../components/data-table-toolbar'
+import { DataTableBulkActions } from './data-table-bulk-actions'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -117,6 +118,7 @@ export function DataTable<TData, TValue>({
         </Table>
       </div>
       <DataTablePagination table={table} />
+      <DataTableBulkActions table={table} />
     </div>
   )
 }

--- a/src/features/tasks/components/tasks-multi-delete-dialog.tsx
+++ b/src/features/tasks/components/tasks-multi-delete-dialog.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useState } from 'react'
+import { Table } from '@tanstack/react-table'
+import { AlertTriangle } from 'lucide-react'
+import { toast } from 'sonner'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+
+interface Props<TData> {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  table: Table<TData>
+}
+
+const CONFIRM_WORD = 'DELETE'
+const promise = () =>
+  new Promise((resolve) =>
+    setTimeout(() => resolve({ name: CONFIRM_WORD }), 2000)
+  )
+
+export function TasksMultiDeleteDialog<TData>({
+  open,
+  onOpenChange,
+  table,
+}: Props<TData>) {
+  const [value, setValue] = useState('')
+
+  const selectedRows = table.getFilteredSelectedRowModel().rows
+
+  const handleDelete = () => {
+    if (value.trim() !== CONFIRM_WORD) {
+      toast.error(`Please type "${CONFIRM_WORD}" to confirm.`)
+      return
+    }
+
+    onOpenChange(false)
+
+    toast.promise(promise, {
+      loading: 'Deleting tasks...',
+      success: () => {
+        table.resetRowSelection()
+        return `Deleted ${selectedRows.length} ${
+          selectedRows.length > 1 ? 'tasks' : 'task'
+        }`
+      },
+      error: 'Error',
+    })
+  }
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      handleConfirm={handleDelete}
+      disabled={value.trim() !== CONFIRM_WORD}
+      title={
+        <span className='text-destructive'>
+          <AlertTriangle
+            className='stroke-destructive me-1 inline-block'
+            size={18}
+          />{' '}
+          Delete {selectedRows.length}{' '}
+          {selectedRows.length > 1 ? 'tasks' : 'task'}
+        </span>
+      }
+      desc={
+        <div className='space-y-4'>
+          <p className='mb-2'>
+            Are you sure you want to delete the selected tasks? <br />
+            This action cannot be undone.
+          </p>
+
+          <Label className='my-4 flex flex-col items-start gap-1.5'>
+            <span className=''>Confirm by typing "{CONFIRM_WORD}":</span>
+            <Input
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={`Type "${CONFIRM_WORD}" to confirm.`}
+            />
+          </Label>
+
+          <Alert variant='destructive'>
+            <AlertTitle>Warning!</AlertTitle>
+            <AlertDescription>
+              Please be carefull, this operation can not be rolled back.
+            </AlertDescription>
+          </Alert>
+        </div>
+      }
+      confirmText='Delete'
+      destructive
+    />
+  )
+}

--- a/src/features/users/components/data-table-bulk-actions.tsx
+++ b/src/features/users/components/data-table-bulk-actions.tsx
@@ -50,17 +50,6 @@ export function DataTableBulkActions<TData>({
     }
   }, [selectedCount])
 
-  // Focus management - focus the toolbar when it appears
-  useEffect(() => {
-    if (selectedCount > 0 && toolbarRef.current) {
-      // Small delay to ensure the toolbar is rendered
-      const timer = setTimeout(() => {
-        toolbarRef.current?.focus()
-      }, 100)
-      return () => clearTimeout(timer)
-    }
-  }, [selectedCount])
-
   if (selectedCount === 0) {
     return null
   }
@@ -114,10 +103,35 @@ export function DataTableBulkActions<TData>({
         event.preventDefault()
         buttons[buttons.length - 1]?.focus()
         break
-      case 'Escape':
+      case 'Escape': {
+        // Check if the Escape key came from a dropdown trigger or content
+        // We can't check dropdown state because Radix UI closes it before our handler runs
+        const target = event.target as HTMLElement
+        const activeElement = document.activeElement as HTMLElement
+
+        // Check if the event target or currently focused element is a dropdown trigger
+        const isFromDropdownTrigger =
+          target?.getAttribute('data-slot') === 'dropdown-menu-trigger' ||
+          activeElement?.getAttribute('data-slot') ===
+            'dropdown-menu-trigger' ||
+          target?.closest('[data-slot="dropdown-menu-trigger"]') ||
+          activeElement?.closest('[data-slot="dropdown-menu-trigger"]')
+
+        // Check if the focused element is inside dropdown content (which is portaled)
+        const isFromDropdownContent =
+          activeElement?.closest('[data-slot="dropdown-menu-content"]') ||
+          target?.closest('[data-slot="dropdown-menu-content"]')
+
+        if (isFromDropdownTrigger || isFromDropdownContent) {
+          // Escape was meant for the dropdown - don't clear selection
+          return
+        }
+
+        // Escape was meant for the toolbar - clear selection
         event.preventDefault()
         handleClearSelection()
         break
+      }
     }
   }
 

--- a/src/features/users/components/data-table-bulk-actions.tsx
+++ b/src/features/users/components/data-table-bulk-actions.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react'
+import { Table } from '@tanstack/react-table'
+import { Trash2, UserX, UserCheck, Mail, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+interface DataTableBulkActionsProps<TData> {
+  table: Table<TData>
+}
+
+/**
+ * Bulk Actions Component for Users Table
+ *
+ * This component provides bulk action functionality when users are selected in the table.
+ * It includes:
+ * - Bulk invite users
+ * - Bulk activate users
+ * - Bulk deactivate users
+ * - Bulk delete users (with confirmation dialog)
+ * - Clear selection option
+ *
+ * The component only renders when at least one row is selected.
+ */
+export function DataTableBulkActions<TData>({
+  table,
+}: DataTableBulkActionsProps<TData>) {
+  const selectedRows = table.getFilteredSelectedRowModel().rows
+  const selectedCount = selectedRows.length
+  const [_showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+
+  if (selectedCount === 0) {
+    return null
+  }
+
+  const handleBulkStatusChange = (_status: string) => {
+    // TODO: Implement bulk status change functionality
+    // const selectedUsers = selectedRows.map((row) => row.original as User)
+    // For now, just clear selection
+    table.resetRowSelection()
+  }
+
+  const handleBulkInvite = () => {
+    // TODO: Implement bulk invite functionality
+    // const selectedUsers = selectedRows.map((row) => row.original as User)
+    // For now, just clear selection
+    table.resetRowSelection()
+  }
+
+  const handleClearSelection = () => {
+    table.resetRowSelection()
+  }
+
+  return (
+    <div
+      role='toolbar'
+      className={cn(
+        'fixed bottom-6 left-1/2 z-50 -translate-x-1/2',
+        'transition-all delay-100 duration-300 ease-out hover:scale-105'
+      )}
+    >
+      <div
+        className={cn(
+          'p-2 shadow-xl',
+          'rounded-xl border',
+          'bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg',
+          'flex items-center gap-x-2'
+        )}
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              onClick={handleClearSelection}
+              className='size-6 rounded-full'
+            >
+              <X />
+              <span className='sr-only'>Clear selection</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Clear selection</p>
+          </TooltipContent>
+        </Tooltip>
+
+        <Separator className='h-5' orientation='vertical' />
+
+        <div className='flex items-center gap-x-1 text-sm'>
+          <Badge variant='default' className='min-w-8 rounded-lg'>
+            {selectedCount}
+          </Badge>
+          {'  '}
+          <span className='hidden sm:inline'>
+            user
+            {selectedCount > 1 ? 's' : ''}{' '}
+          </span>
+          {'  '}
+          selected
+        </div>
+
+        <Separator className='h-5' orientation='vertical' />
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              onClick={handleBulkInvite}
+              className='size-8'
+            >
+              <Mail />
+              <span className='sr-only'>Invite</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Invite</p>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              onClick={() => handleBulkStatusChange('active')}
+              className='size-8'
+            >
+              <UserCheck />
+              <span className='sr-only'>Activate</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Activate</p>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              onClick={() => handleBulkStatusChange('inactive')}
+              className='size-8'
+            >
+              <UserX />
+              <span className='sr-only'>Deactivate</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Deactivate</p>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              onClick={() => setShowDeleteConfirm(true)}
+              className='text-destructive/75 border-destructive/35 dark:text-destructive dark:border-destructive/50 hover:bg-destructive/5 hover:text-destructive size-8'
+            >
+              <Trash2 />
+              <span className='sr-only'>Delete</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Delete</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}

--- a/src/features/users/components/data-table-bulk-actions.tsx
+++ b/src/features/users/components/data-table-bulk-actions.tsx
@@ -10,6 +10,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { UsersMultiDeleteDialog } from './users-multi-delete-dialog'
 
 interface DataTableBulkActionsProps<TData> {
   table: Table<TData>
@@ -33,7 +34,7 @@ export function DataTableBulkActions<TData>({
 }: DataTableBulkActionsProps<TData>) {
   const selectedRows = table.getFilteredSelectedRowModel().rows
   const selectedCount = selectedRows.length
-  const [_showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const toolbarRef = useRef<HTMLDivElement>(null)
   const [announcement, setAnnouncement] = useState('')
 
@@ -281,6 +282,12 @@ export function DataTableBulkActions<TData>({
           </Tooltip>
         </div>
       </div>
+
+      <UsersMultiDeleteDialog
+        table={table}
+        open={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+      />
     </>
   )
 }

--- a/src/features/users/components/data-table-bulk-actions.tsx
+++ b/src/features/users/components/data-table-bulk-actions.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Table } from '@tanstack/react-table'
 import { Trash2, UserX, UserCheck, Mail, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -34,6 +34,31 @@ export function DataTableBulkActions<TData>({
   const selectedRows = table.getFilteredSelectedRowModel().rows
   const selectedCount = selectedRows.length
   const [_showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const toolbarRef = useRef<HTMLDivElement>(null)
+  const [announcement, setAnnouncement] = useState('')
+
+  // Announce selection changes to screen readers
+  useEffect(() => {
+    if (selectedCount > 0) {
+      const message = `${selectedCount} user${selectedCount > 1 ? 's' : ''} selected. Bulk actions toolbar is available.`
+      setAnnouncement(message)
+
+      // Clear announcement after a delay
+      const timer = setTimeout(() => setAnnouncement(''), 3000)
+      return () => clearTimeout(timer)
+    }
+  }, [selectedCount])
+
+  // Focus management - focus the toolbar when it appears
+  useEffect(() => {
+    if (selectedCount > 0 && toolbarRef.current) {
+      // Small delay to ensure the toolbar is rendered
+      const timer = setTimeout(() => {
+        toolbarRef.current?.focus()
+      }, 100)
+      return () => clearTimeout(timer)
+    }
+  }, [selectedCount])
 
   if (selectedCount === 0) {
     return null
@@ -57,124 +82,205 @@ export function DataTableBulkActions<TData>({
     table.resetRowSelection()
   }
 
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    // Handle keyboard navigation within the toolbar
+    const buttons = toolbarRef.current?.querySelectorAll('button')
+    if (!buttons) return
+
+    const currentIndex = Array.from(buttons).findIndex(
+      (button) => button === document.activeElement
+    )
+
+    switch (event.key) {
+      case 'ArrowRight': {
+        event.preventDefault()
+        const nextIndex = (currentIndex + 1) % buttons.length
+        buttons[nextIndex]?.focus()
+        break
+      }
+      case 'ArrowLeft': {
+        event.preventDefault()
+        const prevIndex =
+          currentIndex === 0 ? buttons.length - 1 : currentIndex - 1
+        buttons[prevIndex]?.focus()
+        break
+      }
+      case 'Home':
+        event.preventDefault()
+        buttons[0]?.focus()
+        break
+      case 'End':
+        event.preventDefault()
+        buttons[buttons.length - 1]?.focus()
+        break
+      case 'Escape':
+        event.preventDefault()
+        handleClearSelection()
+        break
+    }
+  }
+
   return (
-    <div
-      role='toolbar'
-      className={cn(
-        'fixed bottom-6 left-1/2 z-50 -translate-x-1/2',
-        'transition-all delay-100 duration-300 ease-out hover:scale-105'
-      )}
-    >
+    <>
+      {/* Live region for screen reader announcements */}
       <div
+        aria-live='polite'
+        aria-atomic='true'
+        className='sr-only'
+        role='status'
+      >
+        {announcement}
+      </div>
+
+      <div
+        ref={toolbarRef}
+        role='toolbar'
+        aria-label={`Bulk actions for ${selectedCount} selected user${selectedCount > 1 ? 's' : ''}`}
+        aria-describedby='bulk-actions-description'
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
         className={cn(
-          'p-2 shadow-xl',
-          'rounded-xl border',
-          'bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg',
-          'flex items-center gap-x-2'
+          'fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-xl',
+          'transition-all delay-100 duration-300 ease-out hover:scale-105',
+          'focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:outline-none'
         )}
       >
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant='outline'
-              size='icon'
-              onClick={handleClearSelection}
-              className='size-6 rounded-full'
+        <div
+          className={cn(
+            'p-2 shadow-xl',
+            'rounded-xl border',
+            'bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg',
+            'flex items-center gap-x-2'
+          )}
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                onClick={handleClearSelection}
+                className='size-6 rounded-full'
+                aria-label='Clear selection'
+                title='Clear selection (Escape)'
+              >
+                <X />
+                <span className='sr-only'>Clear selection</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Clear selection (Escape)</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Separator
+            className='h-5'
+            orientation='vertical'
+            aria-hidden='true'
+          />
+
+          <div
+            className='flex items-center gap-x-1 text-sm'
+            id='bulk-actions-description'
+          >
+            <Badge
+              variant='default'
+              className='min-w-8 rounded-lg'
+              aria-label={`${selectedCount} selected`}
             >
-              <X />
-              <span className='sr-only'>Clear selection</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Clear selection</p>
-          </TooltipContent>
-        </Tooltip>
+              {selectedCount}
+            </Badge>
+            {'  '}
+            <span className='hidden sm:inline'>
+              user
+              {selectedCount > 1 ? 's' : ''}{' '}
+            </span>
+            {'  '}
+            selected
+          </div>
 
-        <Separator className='h-5' orientation='vertical' />
+          <Separator
+            className='h-5'
+            orientation='vertical'
+            aria-hidden='true'
+          />
 
-        <div className='flex items-center gap-x-1 text-sm'>
-          <Badge variant='default' className='min-w-8 rounded-lg'>
-            {selectedCount}
-          </Badge>
-          {'  '}
-          <span className='hidden sm:inline'>
-            user
-            {selectedCount > 1 ? 's' : ''}{' '}
-          </span>
-          {'  '}
-          selected
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                onClick={handleBulkInvite}
+                className='size-8'
+                aria-label='Invite selected users'
+                title='Invite selected users'
+              >
+                <Mail />
+                <span className='sr-only'>Invite selected users</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Invite selected users</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                onClick={() => handleBulkStatusChange('active')}
+                className='size-8'
+                aria-label='Activate selected users'
+                title='Activate selected users'
+              >
+                <UserCheck />
+                <span className='sr-only'>Activate selected users</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Activate selected users</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                onClick={() => handleBulkStatusChange('inactive')}
+                className='size-8'
+                aria-label='Deactivate selected users'
+                title='Deactivate selected users'
+              >
+                <UserX />
+                <span className='sr-only'>Deactivate selected users</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Deactivate selected users</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                onClick={() => setShowDeleteConfirm(true)}
+                className='text-destructive/75 border-destructive/35 dark:text-destructive dark:border-destructive/50 hover:bg-destructive/5 hover:text-destructive size-8'
+                aria-label='Delete selected users'
+                title='Delete selected users'
+              >
+                <Trash2 />
+                <span className='sr-only'>Delete selected users</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Delete selected users</p>
+            </TooltipContent>
+          </Tooltip>
         </div>
-
-        <Separator className='h-5' orientation='vertical' />
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant='outline'
-              size='icon'
-              onClick={handleBulkInvite}
-              className='size-8'
-            >
-              <Mail />
-              <span className='sr-only'>Invite</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Invite</p>
-          </TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant='outline'
-              size='icon'
-              onClick={() => handleBulkStatusChange('active')}
-              className='size-8'
-            >
-              <UserCheck />
-              <span className='sr-only'>Activate</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Activate</p>
-          </TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant='outline'
-              size='icon'
-              onClick={() => handleBulkStatusChange('inactive')}
-              className='size-8'
-            >
-              <UserX />
-              <span className='sr-only'>Deactivate</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Deactivate</p>
-          </TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant='outline'
-              size='icon'
-              onClick={() => setShowDeleteConfirm(true)}
-              className='text-destructive/75 border-destructive/35 dark:text-destructive dark:border-destructive/50 hover:bg-destructive/5 hover:text-destructive size-8'
-            >
-              <Trash2 />
-              <span className='sr-only'>Delete</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Delete</p>
-          </TooltipContent>
-        </Tooltip>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/features/users/components/data-table-bulk-actions.tsx
+++ b/src/features/users/components/data-table-bulk-actions.tsx
@@ -1,301 +1,115 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { Table } from '@tanstack/react-table'
-import { Trash2, UserX, UserCheck, Mail, X } from 'lucide-react'
-import { cn } from '@/lib/utils'
-import { Badge } from '@/components/ui/badge'
+import { Trash2, UserX, UserCheck, Mail } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Separator } from '@/components/ui/separator'
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { BulkActionsToolbar } from '@/components/bulk-actions-toolbar'
 import { UsersMultiDeleteDialog } from './users-multi-delete-dialog'
 
 interface DataTableBulkActionsProps<TData> {
   table: Table<TData>
 }
 
-/**
- * Bulk Actions Component for Users Table
- *
- * This component provides bulk action functionality when users are selected in the table.
- * It includes:
- * - Bulk invite users
- * - Bulk activate users
- * - Bulk deactivate users
- * - Bulk delete users (with confirmation dialog)
- * - Clear selection option
- *
- * The component only renders when at least one row is selected.
- */
 export function DataTableBulkActions<TData>({
   table,
 }: DataTableBulkActionsProps<TData>) {
-  const selectedRows = table.getFilteredSelectedRowModel().rows
-  const selectedCount = selectedRows.length
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-  const toolbarRef = useRef<HTMLDivElement>(null)
-  const [announcement, setAnnouncement] = useState('')
-
-  // Announce selection changes to screen readers
-  useEffect(() => {
-    if (selectedCount > 0) {
-      const message = `${selectedCount} user${selectedCount > 1 ? 's' : ''} selected. Bulk actions toolbar is available.`
-      setAnnouncement(message)
-
-      // Clear announcement after a delay
-      const timer = setTimeout(() => setAnnouncement(''), 3000)
-      return () => clearTimeout(timer)
-    }
-  }, [selectedCount])
-
-  if (selectedCount === 0) {
-    return null
-  }
 
   const handleBulkStatusChange = (_status: string) => {
     // TODO: Implement bulk status change functionality
     // const selectedUsers = selectedRows.map((row) => row.original as User)
-    // For now, just clear selection
     table.resetRowSelection()
   }
 
   const handleBulkInvite = () => {
     // TODO: Implement bulk invite functionality
     // const selectedUsers = selectedRows.map((row) => row.original as User)
-    // For now, just clear selection
     table.resetRowSelection()
-  }
-
-  const handleClearSelection = () => {
-    table.resetRowSelection()
-  }
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    // Handle keyboard navigation within the toolbar
-    const buttons = toolbarRef.current?.querySelectorAll('button')
-    if (!buttons) return
-
-    const currentIndex = Array.from(buttons).findIndex(
-      (button) => button === document.activeElement
-    )
-
-    switch (event.key) {
-      case 'ArrowRight': {
-        event.preventDefault()
-        const nextIndex = (currentIndex + 1) % buttons.length
-        buttons[nextIndex]?.focus()
-        break
-      }
-      case 'ArrowLeft': {
-        event.preventDefault()
-        const prevIndex =
-          currentIndex === 0 ? buttons.length - 1 : currentIndex - 1
-        buttons[prevIndex]?.focus()
-        break
-      }
-      case 'Home':
-        event.preventDefault()
-        buttons[0]?.focus()
-        break
-      case 'End':
-        event.preventDefault()
-        buttons[buttons.length - 1]?.focus()
-        break
-      case 'Escape': {
-        // Check if the Escape key came from a dropdown trigger or content
-        // We can't check dropdown state because Radix UI closes it before our handler runs
-        const target = event.target as HTMLElement
-        const activeElement = document.activeElement as HTMLElement
-
-        // Check if the event target or currently focused element is a dropdown trigger
-        const isFromDropdownTrigger =
-          target?.getAttribute('data-slot') === 'dropdown-menu-trigger' ||
-          activeElement?.getAttribute('data-slot') ===
-            'dropdown-menu-trigger' ||
-          target?.closest('[data-slot="dropdown-menu-trigger"]') ||
-          activeElement?.closest('[data-slot="dropdown-menu-trigger"]')
-
-        // Check if the focused element is inside dropdown content (which is portaled)
-        const isFromDropdownContent =
-          activeElement?.closest('[data-slot="dropdown-menu-content"]') ||
-          target?.closest('[data-slot="dropdown-menu-content"]')
-
-        if (isFromDropdownTrigger || isFromDropdownContent) {
-          // Escape was meant for the dropdown - don't clear selection
-          return
-        }
-
-        // Escape was meant for the toolbar - clear selection
-        event.preventDefault()
-        handleClearSelection()
-        break
-      }
-    }
   }
 
   return (
     <>
-      {/* Live region for screen reader announcements */}
-      <div
-        aria-live='polite'
-        aria-atomic='true'
-        className='sr-only'
-        role='status'
-      >
-        {announcement}
-      </div>
-
-      <div
-        ref={toolbarRef}
-        role='toolbar'
-        aria-label={`Bulk actions for ${selectedCount} selected user${selectedCount > 1 ? 's' : ''}`}
-        aria-describedby='bulk-actions-description'
-        tabIndex={0}
-        onKeyDown={handleKeyDown}
-        className={cn(
-          'fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-xl',
-          'transition-all delay-100 duration-300 ease-out hover:scale-105',
-          'focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:outline-none'
-        )}
-      >
-        <div
-          className={cn(
-            'p-2 shadow-xl',
-            'rounded-xl border',
-            'bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg',
-            'flex items-center gap-x-2'
-          )}
-        >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant='outline'
-                size='icon'
-                onClick={handleClearSelection}
-                className='size-6 rounded-full'
-                aria-label='Clear selection'
-                title='Clear selection (Escape)'
-              >
-                <X />
-                <span className='sr-only'>Clear selection</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Clear selection (Escape)</p>
-            </TooltipContent>
-          </Tooltip>
-
-          <Separator
-            className='h-5'
-            orientation='vertical'
-            aria-hidden='true'
-          />
-
-          <div
-            className='flex items-center gap-x-1 text-sm'
-            id='bulk-actions-description'
-          >
-            <Badge
-              variant='default'
-              className='min-w-8 rounded-lg'
-              aria-label={`${selectedCount} selected`}
+      <BulkActionsToolbar table={table} entityName='user'>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              onClick={handleBulkInvite}
+              className='size-8'
+              aria-label='Invite selected users'
+              title='Invite selected users'
             >
-              {selectedCount}
-            </Badge>
-            {'  '}
-            <span className='hidden sm:inline'>
-              user
-              {selectedCount > 1 ? 's' : ''}{' '}
-            </span>
-            {'  '}
-            selected
-          </div>
+              <Mail />
+              <span className='sr-only'>Invite selected users</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Invite selected users</p>
+          </TooltipContent>
+        </Tooltip>
 
-          <Separator
-            className='h-5'
-            orientation='vertical'
-            aria-hidden='true'
-          />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              onClick={() => handleBulkStatusChange('active')}
+              className='size-8'
+              aria-label='Activate selected users'
+              title='Activate selected users'
+            >
+              <UserCheck />
+              <span className='sr-only'>Activate selected users</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Activate selected users</p>
+          </TooltipContent>
+        </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant='outline'
-                size='icon'
-                onClick={handleBulkInvite}
-                className='size-8'
-                aria-label='Invite selected users'
-                title='Invite selected users'
-              >
-                <Mail />
-                <span className='sr-only'>Invite selected users</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Invite selected users</p>
-            </TooltipContent>
-          </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              onClick={() => handleBulkStatusChange('inactive')}
+              className='size-8'
+              aria-label='Deactivate selected users'
+              title='Deactivate selected users'
+            >
+              <UserX />
+              <span className='sr-only'>Deactivate selected users</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Deactivate selected users</p>
+          </TooltipContent>
+        </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant='outline'
-                size='icon'
-                onClick={() => handleBulkStatusChange('active')}
-                className='size-8'
-                aria-label='Activate selected users'
-                title='Activate selected users'
-              >
-                <UserCheck />
-                <span className='sr-only'>Activate selected users</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Activate selected users</p>
-            </TooltipContent>
-          </Tooltip>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant='outline'
-                size='icon'
-                onClick={() => handleBulkStatusChange('inactive')}
-                className='size-8'
-                aria-label='Deactivate selected users'
-                title='Deactivate selected users'
-              >
-                <UserX />
-                <span className='sr-only'>Deactivate selected users</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Deactivate selected users</p>
-            </TooltipContent>
-          </Tooltip>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant='outline'
-                size='icon'
-                onClick={() => setShowDeleteConfirm(true)}
-                className='text-destructive/75 border-destructive/35 dark:text-destructive dark:border-destructive/50 hover:bg-destructive/5 hover:text-destructive size-8'
-                aria-label='Delete selected users'
-                title='Delete selected users'
-              >
-                <Trash2 />
-                <span className='sr-only'>Delete selected users</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Delete selected users</p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='destructive'
+              size='icon'
+              onClick={() => setShowDeleteConfirm(true)}
+              className='size-8'
+              aria-label='Delete selected users'
+              title='Delete selected users'
+            >
+              <Trash2 />
+              <span className='sr-only'>Delete selected users</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Delete selected users</p>
+          </TooltipContent>
+        </Tooltip>
+      </BulkActionsToolbar>
 
       <UsersMultiDeleteDialog
         table={table}

--- a/src/features/users/components/users-multi-delete-dialog.tsx
+++ b/src/features/users/components/users-multi-delete-dialog.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useState } from 'react'
+import { Table } from '@tanstack/react-table'
+import { AlertTriangle } from 'lucide-react'
+import { toast } from 'sonner'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+
+interface Props<TData> {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  table: Table<TData>
+}
+
+const CONFIRM_WORD = 'DELETE'
+const promise = () =>
+  new Promise((resolve) =>
+    setTimeout(() => resolve({ name: CONFIRM_WORD }), 2000)
+  )
+
+export function UsersMultiDeleteDialog<TData>({
+  open,
+  onOpenChange,
+  table,
+}: Props<TData>) {
+  const [value, setValue] = useState('')
+
+  const selectedRows = table.getFilteredSelectedRowModel().rows
+
+  const handleDelete = () => {
+    if (value.trim() !== CONFIRM_WORD) {
+      toast.error(`Please type "${CONFIRM_WORD}" to confirm.`)
+      return
+    }
+
+    onOpenChange(false)
+
+    toast.promise(promise, {
+      loading: 'Deleting users...',
+      success: () => {
+        table.resetRowSelection()
+        return `Deleted ${selectedRows.length} ${
+          selectedRows.length > 1 ? 'users' : 'user'
+        }`
+      },
+      error: 'Error',
+    })
+  }
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      handleConfirm={handleDelete}
+      disabled={value.trim() !== CONFIRM_WORD}
+      title={
+        <span className='text-destructive'>
+          <AlertTriangle
+            className='stroke-destructive me-1 inline-block'
+            size={18}
+          />{' '}
+          Delete {selectedRows.length}{' '}
+          {selectedRows.length > 1 ? 'users' : 'user'}
+        </span>
+      }
+      desc={
+        <div className='space-y-4'>
+          <p className='mb-2'>
+            Are you sure you want to delete the selected users? <br />
+            This action cannot be undone.
+          </p>
+
+          <Label className='my-4 flex flex-col items-start gap-1.5'>
+            <span className=''>Confirm by typing "{CONFIRM_WORD}":</span>
+            <Input
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={`Type "${CONFIRM_WORD}" to confirm.`}
+            />
+          </Label>
+
+          <Alert variant='destructive'>
+            <AlertTitle>Warning!</AlertTitle>
+            <AlertDescription>
+              Please be carefull, this operation can not be rolled back.
+            </AlertDescription>
+          </Alert>
+        </div>
+      }
+      confirmText='Delete'
+      destructive
+    />
+  )
+}

--- a/src/features/users/components/users-table.tsx
+++ b/src/features/users/components/users-table.tsx
@@ -24,6 +24,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { User } from '../data/schema'
+import { DataTableBulkActions } from './data-table-bulk-actions'
 import { DataTablePagination } from './data-table-pagination'
 import { DataTableToolbar } from './data-table-toolbar'
 
@@ -68,7 +69,7 @@ export function UsersTable({ columns, data }: DataTableProps) {
   })
 
   return (
-    <div className='space-y-4'>
+    <div className='space-y-4 max-sm:has-[div[role="toolbar"]]:mb-16'>
       <DataTableToolbar table={table} />
       <div className='overflow-hidden rounded-md border'>
         <Table>
@@ -135,6 +136,7 @@ export function UsersTable({ columns, data }: DataTableProps) {
         </Table>
       </div>
       <DataTablePagination table={table} />
+      <DataTableBulkActions table={table} />
     </div>
   )
 }


### PR DESCRIPTION
## Description

This commit introduces a new bulk action toolbar that appears when a user selects one or more rows in a data table, providing an intuitive way to perform actions on multiple items at once.

The new `BulkActionsToolbar` is a generic and reusable component designed with accessibility in mind. It features full keyboard navigation (Arrow keys, Home, End, Escape) and provides ARIA live announcements for screen readers.

Key features include:
- A floating design that remains fixed at the bottom of the viewport.
- Bulk actions for the Tasks table: update status, change priority, export, and delete.
- Bulk actions for the Users table: invite, activate/deactivate, and delete.
- A confirmation dialog for destructive actions, requiring the user to type "DELETE" to proceed.

https://github.com/user-attachments/assets/ee55b790-cf51-4910-b998-5c4798b132a5

## Types of changes

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Related Issue

Closes: #135