### PR TITLE
FIX[Sidebar]: resolve issue with `chevron direction` of sidebar's menu button for `RTL`

### DIFF
--- a/src/components/layout/nav-group.tsx
+++ b/src/components/layout/nav-group.tsx
@@ -101,7 +101,7 @@ function SidebarMenuCollapsible({
             {item.icon && <item.icon />}
             <span>{item.title}</span>
             {item.badge && <NavBadge>{item.badge}</NavBadge>}
-            <ChevronRight className='ms-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90' />
+            <ChevronRight className='ms-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90 rtl:rotate-180' />
           </SidebarMenuButton>
         </CollapsibleTrigger>
         <CollapsibleContent className='CollapsibleContent'>


### PR DESCRIPTION
## Description
resolve issue with `chevron direction` of sidebar's menu button for `RTL`

**before:**
<img width="476" height="709" alt="brave_screenshot_localhost (1)" src="https://github.com/user-attachments/assets/7f5be7d1-e973-4f12-8ba5-63ceca5b1c93" />

**after:**
<img width="486" height="840" alt="brave_screenshot_localhost (3)" src="https://github.com/user-attachments/assets/e18afa37-2cae-4c8e-b0ac-7abfd88d5447" />

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist


- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)


## Related Issue

Closes: #228