### PR TITLE
fix: prevent navigation to 500 page during development

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -59,7 +59,10 @@ const queryClient = new QueryClient({
         }
         if (error.response?.status === 500) {
           toast.error('Internal Server Error!')
-          router.navigate({ to: '/500' })
+          // Only navigate to error page in production to avoid disrupting HMR in development
+          if (import.meta.env.PROD) {
+            router.navigate({ to: '/500' })
+          }
         }
         if (error.response?.status === 403) {
           // router.navigate("/forbidden", { replace: true });


### PR DESCRIPTION
## Description

Only navigate to /500 error page in production environment to avoid disrupting developer experience during HMR reloads. Toast notification still shows in both environments for visibility.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Related Issue

Fixes #225