### PR TITLE
fix(charts): Ensure Bar Chart Y-axis is visible in RTL

### DIFF
--- a/src/features/dashboard/components/overview.tsx
+++ b/src/features/dashboard/components/overview.tsx
@@ -63,6 +63,7 @@ export function Overview() {
           axisLine={false}
         />
         <YAxis
+          direction='ltr'
           stroke='#888888'
           fontSize={12}
           tickLine={false}


### PR DESCRIPTION
## Description

This pull request (PR) fixes a visual bug in the Bar Chart component that occurred when the application's layout direction was set to RTL (Right-to-Left).

Previously, in RTL mode, the chart's Y-axis would render behind the chart bars, making it unreadable and unusable.

This fix ensures the Y-axis is correctly positioned and remains visible in all layout directions.

## Types of changes

- [ x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

<img width="728" height="471" alt="image" src="https://github.com/user-attachments/assets/47ab7d65-ce2c-4917-b10c-64da0a44919e" />

<img width="725" height="468" alt="image" src="https://github.com/user-attachments/assets/73a89aed-22a5-4b1f-b6f8-d2c68b04c314" />
