### PR TITLE
fix(confirm-dialog): allow form submission on confirmation

### DIFF
--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -38,6 +38,8 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     destructive,
     isLoading,
     disabled = false,
+    form,
+    handleConfirm,
     ...actions
   } = props
   return (
@@ -55,9 +57,9 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
             {cancelBtnText ?? 'Cancel'}
           </AlertDialogCancel>
           <Button
-            type={props.form ? 'submit' : 'button'}
-            form={props.form}
-            onClick={props.handleConfirm}
+            type={form ? 'submit' : 'button'}
+            form={form}
+            onClick={handleConfirm}
             variant={destructive ? 'destructive' : 'default'}
             disabled={disabled || isLoading}
           >

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -19,11 +19,13 @@ type ConfirmDialogProps = {
   cancelBtnText?: string
   confirmText?: React.ReactNode
   destructive?: boolean
-  handleConfirm: () => void
   isLoading?: boolean
   className?: string
   children?: React.ReactNode
-}
+} & (
+  | { form: string; handleConfirm?: undefined }
+  | { form?: undefined; handleConfirm: () => void }
+)
 
 export function ConfirmDialog(props: ConfirmDialogProps) {
   const {
@@ -36,7 +38,6 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     destructive,
     isLoading,
     disabled = false,
-    handleConfirm,
     ...actions
   } = props
   return (
@@ -54,8 +55,10 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
             {cancelBtnText ?? 'Cancel'}
           </AlertDialogCancel>
           <Button
+            type={props.form ? 'submit' : 'button'}
+            form={props.form}
+            onClick={props.handleConfirm}
             variant={destructive ? 'destructive' : 'default'}
-            onClick={handleConfirm}
             disabled={disabled || isLoading}
           >
             {confirmText ?? 'Continue'}

--- a/src/features/tasks/components/tasks-multi-delete-dialog.tsx
+++ b/src/features/tasks/components/tasks-multi-delete-dialog.tsx
@@ -52,7 +52,7 @@ export function TasksMultiDeleteDialog<TData>({
     <ConfirmDialog
       open={open}
       onOpenChange={onOpenChange}
-      handleConfirm={handleDelete}
+      form='tasks-multi-delete-form'
       disabled={value.trim() !== CONFIRM_WORD}
       title={
         <span className='text-destructive'>
@@ -65,7 +65,14 @@ export function TasksMultiDeleteDialog<TData>({
         </span>
       }
       desc={
-        <div className='space-y-4'>
+        <form
+          id='tasks-multi-delete-form'
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleDelete()
+          }}
+          className='space-y-4'
+        >
           <p className='mb-2'>
             Are you sure you want to delete the selected tasks? <br />
             This action cannot be undone.
@@ -86,7 +93,7 @@ export function TasksMultiDeleteDialog<TData>({
               Please be careful, this operation can not be rolled back.
             </AlertDescription>
           </Alert>
-        </div>
+        </form>
       }
       confirmText='Delete'
       destructive

--- a/src/features/tasks/components/tasks-multi-delete-dialog.tsx
+++ b/src/features/tasks/components/tasks-multi-delete-dialog.tsx
@@ -84,6 +84,7 @@ export function TasksMultiDeleteDialog<TData>({
               value={value}
               onChange={(e) => setValue(e.target.value)}
               placeholder={`Type "${CONFIRM_WORD}" to confirm.`}
+              autoFocus
             />
           </Label>
 

--- a/src/features/users/components/users-delete-dialog.tsx
+++ b/src/features/users/components/users-delete-dialog.tsx
@@ -33,7 +33,7 @@ export function UsersDeleteDialog({
     <ConfirmDialog
       open={open}
       onOpenChange={onOpenChange}
-      handleConfirm={handleDelete}
+      form='users-delete-form'
       disabled={value.trim() !== currentRow.username}
       title={
         <span className='text-destructive'>
@@ -45,7 +45,14 @@ export function UsersDeleteDialog({
         </span>
       }
       desc={
-        <div className='space-y-4'>
+        <form
+          id='users-delete-form'
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleDelete()
+          }}
+          className='space-y-4'
+        >
           <p className='mb-2'>
             Are you sure you want to delete{' '}
             <span className='font-bold'>{currentRow.username}</span>?
@@ -72,7 +79,7 @@ export function UsersDeleteDialog({
               Please be careful, this operation can not be rolled back.
             </AlertDescription>
           </Alert>
-        </div>
+        </form>
       }
       confirmText='Delete'
       destructive

--- a/src/features/users/components/users-delete-dialog.tsx
+++ b/src/features/users/components/users-delete-dialog.tsx
@@ -70,6 +70,7 @@ export function UsersDeleteDialog({
               value={value}
               onChange={(e) => setValue(e.target.value)}
               placeholder='Enter username to confirm deletion.'
+              autoFocus
             />
           </Label>
 

--- a/src/features/users/components/users-multi-delete-dialog.tsx
+++ b/src/features/users/components/users-multi-delete-dialog.tsx
@@ -52,7 +52,7 @@ export function UsersMultiDeleteDialog<TData>({
     <ConfirmDialog
       open={open}
       onOpenChange={onOpenChange}
-      handleConfirm={handleDelete}
+      form='users-multi-delete-form'
       disabled={value.trim() !== CONFIRM_WORD}
       title={
         <span className='text-destructive'>
@@ -65,7 +65,14 @@ export function UsersMultiDeleteDialog<TData>({
         </span>
       }
       desc={
-        <div className='space-y-4'>
+        <form
+          id='users-multi-delete-form'
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleDelete()
+          }}
+          className='space-y-4'
+        >
           <p className='mb-2'>
             Are you sure you want to delete the selected users? <br />
             This action cannot be undone.
@@ -77,6 +84,7 @@ export function UsersMultiDeleteDialog<TData>({
               value={value}
               onChange={(e) => setValue(e.target.value)}
               placeholder={`Type "${CONFIRM_WORD}" to confirm.`}
+              autoFocus
             />
           </Label>
 
@@ -86,7 +94,7 @@ export function UsersMultiDeleteDialog<TData>({
               Please be careful, this operation can not be rolled back.
             </AlertDescription>
           </Alert>
-        </div>
+        </form>
       }
       confirmText='Delete'
       destructive


### PR DESCRIPTION
## Description

Modified ConfirmDialog component to accept a form prop, allowing for form-based confirmation handling. Updated UsersDeleteDialog, UsersMultiDeleteDialog and TasksMultiDeleteDialog to utilize the new form functionality,allowing users to delete users by pressing Enter key.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change that mainly affects confirmation dialogs; main risk is unintended submit/click behavior in consumers if `form`/`handleConfirm` props are miswired.
> 
> **Overview**
> `ConfirmDialog` now supports a `form` prop that turns the confirm button into a submit button (and makes `form` vs `handleConfirm` mutually exclusive via typing).
> 
> User/task delete dialogs switch their confirmation content to real `<form>`s wired to `onSubmit`, enabling Enter-to-confirm behavior (and adds `autoFocus` in `UsersMultiDeleteDialog`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7843f7f2fdfee1ea7a1f376c323522c251a734cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->