### PR TITLE
refactor(search): update props type and enhance a11y

### DIFF
--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -3,24 +3,21 @@ import { cn } from '@/lib/utils'
 import { useSearch } from '@/context/search-provider'
 import { Button } from './ui/button'
 
-type SearchProps = {
-  className?: string
-  type?: React.HTMLInputTypeAttribute
-  placeholder?: string
-}
-
 export function Search({
   className = '',
   placeholder = 'Search',
-}: SearchProps) {
+  ...props
+}: React.ComponentProps<'button'> & { placeholder?: string }) {
   const { setOpen } = useSearch()
   return (
     <Button
+      {...props}
       variant='outline'
       className={cn(
         'group relative h-8 w-full flex-1 justify-start rounded-md bg-muted/25 text-sm font-normal text-muted-foreground shadow-none hover:bg-accent sm:w-40 sm:pe-12 md:flex-none lg:w-52 xl:w-64',
         className
       )}
+      aria-keyshortcuts='Meta+K Control+K'
       onClick={() => setOpen(true)}
     >
       <SearchIcon


### PR DESCRIPTION
## Description

Refactor the Search component to accept additional button props and improve accessibility by adding aria-keyshortcuts. Remove the explicit SearchProps type definition for a more flexible prop structure.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Refactor
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)
