### PR TITLE
fix(style): added flex for alignment

### DIFF
--- a/src/routes/clerk/route.tsx
+++ b/src/routes/clerk/route.tsx
@@ -43,7 +43,7 @@ function MissingClerkPubKey() {
     <AuthenticatedLayout>
       <div className='bg-backgroundh-16 flex justify-between p-4'>
         <SidebarTrigger variant='outline' className='scale-125 sm:scale-100' />
-        <div className='space-x-4'>
+        <div className='flex items-center gap-4'>
           <ThemeSwitch />
           <ConfigDrawer />
         </div>


### PR DESCRIPTION
## Description

I added flex to a parent div to make sure the icons were aligned.

Before Change:

<img width="1308" height="70" alt="image" src="https://github.com/user-attachments/assets/e94d7ad3-b2c3-4ffe-b1a0-a2d7d46ada86" />

After Change:
<img width="1308" height="70" alt="image" src="https://github.com/user-attachments/assets/abdfd04d-6064-496f-b0a4-01791123da9c" />



## Types of changes

- [x] Bug Fix (fixes an issue)
- [ ] New Feature (adds functionality)
- [x] Refactor (improves code structure without changing behavior)
- [ ] Breaking Change (incompatible change to existing behavior or public API)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Further comments

First time contributing :)

## Related Issue


This is a fix to this [issue 302](https://github.com/satnaing/shadcn-admin/issues/302).

