### PR TITLE
Fixed issue [#139]

### DIFF
--- a/src/components/theme-switch.test.tsx
+++ b/src/components/theme-switch.test.tsx
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { userEvent } from 'vitest/browser'
+import { ThemeProvider } from '@/context/theme-provider'
+import { getCookie } from '@/lib/cookies'
+import { clearCookies } from '@/test-utils/cookies'
+import { ThemeSwitch } from './theme-switch'
+
+const THEME_STORAGE_KEY = 'theme-switch-test-theme'
+
+async function renderThemeSwitch(defaultTheme: 'light' | 'dark' | 'system') {
+    return await render(
+        <ThemeProvider defaultTheme={defaultTheme} storageKey={THEME_STORAGE_KEY}>
+            <ThemeSwitch />
+        </ThemeProvider>
+    )
+}
+
+function ensureThemeColorMeta(initialContent = 'initial') {
+    let metaThemeColor = document.querySelector(
+        "meta[name='theme-color']"
+    ) as HTMLMetaElement | null
+
+    if (!metaThemeColor) {
+        metaThemeColor = document.createElement('meta')
+        metaThemeColor.setAttribute('name', 'theme-color')
+        document.head.appendChild(metaThemeColor)
+    }
+
+    metaThemeColor.setAttribute('content', initialContent)
+    return metaThemeColor
+}
+
+function mockSystemTheme(resolvedTheme: 'light' | 'dark') {
+    const isDark = resolvedTheme === 'dark'
+
+    return vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+        const matches = query === '(prefers-color-scheme: dark)' ? isDark : false
+
+        return {
+            matches,
+            media: query,
+            onchange: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        } as unknown as MediaQueryList
+    })
+}
+
+describe('ThemeSwitch', () => {
+    beforeEach(() => {
+        clearCookies(THEME_STORAGE_KEY)
+        document.querySelector("meta[name='theme-color']")?.remove()
+        document.documentElement.classList.remove('light', 'dark')
+    })
+
+    it('does not re-trigger theme-color update when switching from system to light while system theme is light', async () => {
+        mockSystemTheme('light')
+        const metaThemeColor = ensureThemeColorMeta()
+        const setAttributeSpy = vi.spyOn(metaThemeColor, 'setAttribute')
+
+        const screen = await renderThemeSwitch('system')
+
+        await vi.waitFor(() =>
+            expect(metaThemeColor.getAttribute('content')).toBe('#fff')
+        )
+        const contentCallsAfterMount = setAttributeSpy.mock.calls.filter(
+            ([key]) => key === 'content'
+        ).length
+
+        await userEvent.click(screen.getByRole('button', { name: /toggle theme/i }))
+        await userEvent.click(screen.getByRole('menuitem', { name: /^light$/i }))
+
+        await vi.waitFor(() => expect(getCookie(THEME_STORAGE_KEY)).toBe('light'))
+
+        const contentCallsAfterSwitch = setAttributeSpy.mock.calls.filter(
+            ([key]) => key === 'content'
+        ).length
+
+        expect(contentCallsAfterSwitch).toBe(contentCallsAfterMount)
+    })
+
+    it('does not re-trigger theme-color update when switching from light to system while system theme is light', async () => {
+        mockSystemTheme('light')
+        const metaThemeColor = ensureThemeColorMeta()
+        const setAttributeSpy = vi.spyOn(metaThemeColor, 'setAttribute')
+
+        const screen = await renderThemeSwitch('light')
+
+        await vi.waitFor(() =>
+            expect(metaThemeColor.getAttribute('content')).toBe('#fff')
+        )
+        const contentCallsAfterMount = setAttributeSpy.mock.calls.filter(
+            ([key]) => key === 'content'
+        ).length
+
+        await userEvent.click(screen.getByRole('button', { name: /toggle theme/i }))
+        await userEvent.click(screen.getByRole('menuitem', { name: /^system$/i }))
+
+        await vi.waitFor(() => expect(getCookie(THEME_STORAGE_KEY)).toBe('system'))
+
+        const contentCallsAfterSwitch = setAttributeSpy.mock.calls.filter(
+            ([key]) => key === 'content'
+        ).length
+
+        expect(contentCallsAfterSwitch).toBe(contentCallsAfterMount)
+    })
+})

--- a/src/components/theme-switch.tsx
+++ b/src/components/theme-switch.tsx
@@ -11,15 +11,15 @@ import {
 } from '@/components/ui/dropdown-menu'
 
 export function ThemeSwitch() {
-  const { theme, setTheme } = useTheme()
+  const { theme, resolvedTheme, setTheme } = useTheme()
 
   /* Update theme-color meta tag
-   * when theme is updated */
+   * when resolvedTheme is updated */
   useEffect(() => {
-    const themeColor = theme === 'dark' ? '#020817' : '#fff'
+    const themeColor = resolvedTheme === 'dark' ? '#020817' : '#fff'
     const metaThemeColor = document.querySelector("meta[name='theme-color']")
     if (metaThemeColor) metaThemeColor.setAttribute('content', themeColor)
-  }, [theme])
+  }, [resolvedTheme])
 
   return (
     <DropdownMenu modal={false}>


### PR DESCRIPTION
## Description

When the user selects `system` as their theme preference, the `meta[name='theme-color']` tag always sets its content to '#fff' (light mode color), regardless of the operating system's actual color scheme. This causes the browser address bar / tab bar color to mismatch the actual page theme.

The root cause is that the code uses the theme state (which can be `light`, `dark`, or `system`) instead of resolvedTheme (which is always `light` or `dark` after evaluating the system preference). When theme === `system`, the ternary expression theme === `dark` ? '#020817' : '#fff' always evaluates to '#fff', even if the OS is in dark mode

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

## Types of changes

<!-- What types of changes does your code introduce to shadcn-admin? Put an `x` in the boxes that apply -->

- [x] Bug Fix (fixes an issue)
- [ ] New Feature (adds functionality)
- [ ] Refactor (improves code structure without changing behavior)
- [ ] Breaking Change (incompatible change to existing behavior or public API)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/shadcn-admin/blob/main/.github/CONTRIBUTING.md)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #309
