### PR TITLE
test: add unit tests for cn utility

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getPageNumbers } from './utils'
+import { cn, getPageNumbers } from './utils'
 
 describe('getPageNumbers', () => {
   it('returns all pages when total is at most 5', () => {
@@ -24,5 +24,35 @@ describe('getPageNumbers', () => {
   it('handles current page greater than total pages', () => {
     expect(getPageNumbers(6, 5)).toEqual([1, 2, 3, 4, 5])
     expect(getPageNumbers(11, 10)).toEqual([1, '...', 7, 8, 9, 10])
+  })
+})
+
+describe('cn', () => {
+  it('returns an empty string when given no inputs', () => {
+    expect(cn()).toBe('')
+  })
+
+  it('joins multiple class names with a space', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('keeps truthy conditionals and drops falsy ones', () => {
+    expect(cn('foo', false && 'hidden', true && 'block')).toBe('foo block')
+    expect(cn('foo', undefined, null, 'bar')).toBe('foo bar')
+  })
+
+  it('flattens nested arrays of class values', () => {
+    expect(cn('foo', ['bar', ['baz', false, 'qux']])).toBe('foo bar baz qux')
+  })
+
+  it('resolves tailwind conflicts by keeping the last value', () => {
+    expect(cn('px-2', 'px-4')).toBe('px-4')
+    expect(cn('text-red-500', 'text-blue-500', 'font-bold')).toBe(
+      'text-blue-500 font-bold'
+    )
+  })
+
+  it('resolves conflicts across conditionals and arrays', () => {
+    expect(cn('p-2', ['p-4'], false && 'p-8', 'p-6')).toBe('p-6')
   })
 })


### PR DESCRIPTION
## Summary

Add a test suite for the `cn` helper in `src/lib/utils.ts`, extending the existing `src/lib/utils.test.ts` (which previously only covered `getPageNumbers`).

## What's covered

The `cn` function composes `clsx` + `tailwind-merge`. The new `describe('cn')` block covers:

- Empty input returns `''`
- Joining multiple class names with a space
- Truthy/falsy conditionals (keeps truthy, drops `false`/`null`/`undefined`)
- Nested array flattening
- `tailwind-merge` conflict resolution (last conflicting class wins, e.g. `px-2 px-4` -> `px-4`)
- Combined conditionals + arrays + conflict resolution

## How to run

```sh
npx vitest run src/lib/utils.test.ts --browser.headless
```

## Notes

`node_modules` was not installed in the authoring environment, so the suite was not executed here. All expectations follow the documented behavior of `clsx` and `tailwind-merge`.